### PR TITLE
Add SQLite persistence cache and harden data loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 build/
 .venv/
 venv/
+data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+PostalCode2NUTS is a FastAPI microservice that maps European postal codes to NUTS codes (Nomenclature of Territorial Units for Statistics) using GISCO TERCET flat files from the European Union. Python 3.12, no database — all data is held in-memory for O(1) lookups.
+
+## Build & Run
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run locally with hot-reload
+uvicorn app.main:app --reload --port 8000
+
+# Docker
+docker build -t postalcode2nuts:latest .
+docker run -p 8000:8000 postalcode2nuts:latest
+```
+
+API docs are auto-generated at `/docs` (Swagger) and `/redoc`.
+
+## Environment Variables
+
+All settings are overridable via environment variables prefixed with `PC2NUTS_`:
+
+- `PC2NUTS_TERCET_BASE_URL` — GISCO TERCET base URL (default: NUTS-2024 endpoint)
+- `PC2NUTS_NUTS_VERSION` — NUTS standard version (default: `"2024"`)
+- `PC2NUTS_DATA_DIR` — Cache dir for downloaded ZIPs and SQLite DB (default: `./data`)
+- `PC2NUTS_DB_CACHE_TTL_DAYS` — Max age of the SQLite cache in days before rebuild (default: `30`)
+
+## Architecture
+
+**Startup flow:** FastAPI lifespan event → `data_loader.load_data()` → checks for valid SQLite cache → if fresh, loads directly into `_lookup` dict (~1s); otherwise downloads/caches TERCET ZIPs → parses CSV/TSV → populates `_lookup` → saves to SQLite cache for next startup.
+
+**SQLite persistence cache:** Parsed lookup data is cached in `{data_dir}/postalcode2nuts_NUTS-{version}.db`. The DB holds a `metadata` table (version, creation timestamp, entry count) and a `lookup` table (country_code, postal_code, nuts3). Writes are atomic via temp file + rename. If the TERCET server is down, a valid cached DB ensures the service still starts with data.
+
+**Two-phase data loading:** First tries discovering ZIPs from directory listing HTML; then falls back to guessing URLs with known naming patterns for any missing countries.
+
+**Postal code normalization:** All codes are uppercased with spaces, dashes, and special chars stripped before storage and lookup. This handles format variations across countries (PL: "00-950", SE: "111 22", UK: "SW1A 1AA").
+
+**NUTS level derivation:** Only NUTS3 is stored. NUTS1 and NUTS2 are derived by slicing the NUTS3 code (e.g., `PL213` → NUTS1=`PL2`, NUTS2=`PL21`, NUTS3=`PL213`).
+
+**Greece special case:** ISO code `GR` is mapped to GISCO code `EL` in the lookup function.
+
+## Key Modules
+
+- `app/main.py` — FastAPI app, lifespan handler, `/lookup` and `/health` endpoints
+- `app/data_loader.py` — Core logic: ZIP download/caching, CSV parsing, postal code normalization, lookup function
+- `app/config.py` — Pydantic Settings with `PC2NUTS_` env prefix; defines supported countries list (37 countries/territories)
+- `app/models.py` — Pydantic response models: `NUTSResult`, `ErrorResponse`, `HealthResponse`
+
+## Testing
+
+No test suite exists yet. Key areas to test: `normalize_postal_code()`, `_parse_csv_content()`, `lookup()` (including Greece GR→EL mapping), and the `/lookup` + `/health` endpoints.
+
+## Data Source
+
+GISCO TERCET flat files, (c) European Union, licensed CC-BY-SA 4.0. Covers EU-27, EFTA, candidate countries, and UK.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app/ ./app/
 
+VOLUME ["/app/data"]
+
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/config.py
+++ b/app/config.py
@@ -6,7 +6,8 @@ class Settings(BaseSettings):
         "https://gisco-services.ec.europa.eu/tercet/NUTS-2024/"
     )
     nuts_version: str = "2024"
-    data_dir: str = "/tmp/postalcode2nuts_data"
+    data_dir: str = "./data"
+    db_cache_ttl_days: int = 30
 
     # Countries covered by TERCET (EU + EFTA + candidates + UK)
     countries: list[str] = [

--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -3,14 +3,19 @@
 import csv
 import io
 import logging
-import os
 import re
+import sqlite3
+import time
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
 
 from app.config import settings
+
+_NUTS3_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{1,3}$")
+_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60  # 30 days
 
 logger = logging.getLogger(__name__)
 
@@ -49,31 +54,36 @@ def _discover_zip_urls(client: httpx.Client, base_url: str) -> list[str]:
     return urls
 
 
-def _guess_zip_urls(base_url: str, countries: list[str]) -> list[str]:
-    """Generate candidate ZIP URLs using known naming patterns."""
+def _guess_zip_urls_for_country(base_url: str, country_code: str):
+    """Yield candidate ZIP URLs for a single country, most likely first."""
     base = base_url.rstrip("/")
-    urls: list[str] = []
-    # Try multiple postal-code-year / version combinations
     for pc_year in ("2025", "2024", "2023", "2020"):
         for version in ("v1.0", "v2.0", "v3.0", "v4.0"):
-            for cc in countries:
-                urls.append(
-                    f"{base}/pc{pc_year}_{cc}_NUTS-{settings.nuts_version}_{version}.zip"
-                )
-    return urls
+            yield f"{base}/pc{pc_year}_{country_code}_NUTS-{settings.nuts_version}_{version}.zip"
+
+
+def _sniff_dialect(text: str) -> csv.Dialect | None:
+    """Detect CSV dialect (delimiter + quotechar) using csv.Sniffer."""
+    sample = "\n".join(text.split("\n", 10)[:10])
+    try:
+        return csv.Sniffer().sniff(sample, delimiters=",;\t")
+    except csv.Error:
+        return None
 
 
 def _parse_csv_content(text: str, country_code: str) -> int:
     """Parse CSV/TSV content and populate the lookup table. Returns row count."""
     count = 0
-    # Auto-detect delimiter
-    first_line = text.split("\n", 1)[0]
-    delimiter = "\t" if "\t" in first_line else ","
-    if ";" in first_line and delimiter == ",":
-        # Some EU files use semicolons
-        delimiter = ";"
+    skipped = 0
 
-    reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+    dialect = _sniff_dialect(text)
+    if dialect is not None:
+        reader = csv.DictReader(io.StringIO(text), dialect=dialect)
+    else:
+        # Fallback heuristic for delimiter only
+        first_line = text.split("\n", 1)[0]
+        delimiter = "\t" if "\t" in first_line else ";" if ";" in first_line else ","
+        reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
     fieldnames = [f.strip().upper() for f in (reader.fieldnames or [])]
 
     # Find the postal code column
@@ -83,9 +93,9 @@ def _parse_csv_content(text: str, country_code: str) -> int:
             pc_col = candidate
             break
 
-    # Find the NUTS3 column
+    # Find the NUTS3 column — prefer current version, never fall back to old versions
     nuts3_col = None
-    for candidate in ("NUTS3", "NUTS_ID", "NUTS3_2024", "NUTS3_2021", "NUTS"):
+    for candidate in (f"NUTS3_{settings.nuts_version}", "NUTS3", "NUTS_ID", "NUTS"):
         if candidate in fieldnames:
             nuts3_col = candidate
             break
@@ -106,13 +116,47 @@ def _parse_csv_content(text: str, country_code: str) -> int:
 
     for row in reader:
         pc = row.get(pc_orig, "")
-        nuts3 = row.get(nuts3_orig, "")
-        if pc and nuts3:
-            key = (country_code.upper(), normalize_postal_code(pc))
-            _lookup[key] = nuts3.strip()
+        nuts3 = row.get(nuts3_orig, "").strip()
+        if not pc or not nuts3:
+            continue
+        # Validate NUTS3 code format
+        if not _NUTS3_RE.match(nuts3):
+            skipped += 1
+            continue
+        key = (country_code.upper(), normalize_postal_code(pc))
+        # First-write-wins: discovery-phase data takes priority
+        if key not in _lookup:
+            _lookup[key] = nuts3
             count += 1
 
+    if skipped:
+        logger.warning(
+            "Skipped %d rows with invalid NUTS3 codes for %s", skipped, country_code
+        )
     return count
+
+
+def _download_zip(client: httpx.Client, url: str) -> bytes | None:
+    """Download a ZIP with one retry on transient network errors.
+
+    Returns raw bytes on success, None on failure or 404.
+    """
+    for attempt in range(2):
+        try:
+            resp = client.get(url, timeout=60, follow_redirects=True)
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return resp.content
+        except httpx.HTTPStatusError:
+            return None
+        except httpx.RequestError as exc:
+            if attempt == 0:
+                logger.debug("Transient error downloading %s, retrying: %s", url, exc)
+                time.sleep(2)
+            else:
+                logger.warning("Failed to download %s after 2 attempts: %s", url, exc)
+    return None
 
 
 def _download_and_parse_zip(
@@ -122,24 +166,34 @@ def _download_and_parse_zip(
     filename = url.rsplit("/", 1)[-1]
     cached = cache_dir / filename
 
-    content: bytes
+    content: bytes | None = None
+
     if cached.exists():
-        logger.info("Using cached file %s", cached)
-        content = cached.read_bytes()
-    else:
+        # Check cache TTL — re-download if older than 30 days
+        age = time.time() - cached.stat().st_mtime
+        if age > _CACHE_TTL_SECONDS:
+            logger.info("Cache expired for %s (%.0f days old), re-downloading", cached.name, age / 86400)
+            cached.unlink()
+        else:
+            content = cached.read_bytes()
+            # Validate cached file is a real ZIP
+            if not zipfile.is_zipfile(io.BytesIO(content)):
+                logger.warning("Corrupt cached file %s, deleting and re-downloading", cached.name)
+                cached.unlink()
+                content = None
+            else:
+                logger.info("Using cached file %s", cached)
+
+    if content is None:
         logger.info("Downloading %s", url)
-        try:
-            resp = client.get(url, timeout=60, follow_redirects=True)
-            if resp.status_code == 404:
-                return 0
-            resp.raise_for_status()
-            content = resp.content
-            cached.write_bytes(content)
-        except httpx.HTTPStatusError:
+        content = _download_zip(client, url)
+        if content is None:
             return 0
-        except httpx.RequestError as exc:
-            logger.warning("Failed to download %s: %s", url, exc)
+        # Validate before caching
+        if not zipfile.is_zipfile(io.BytesIO(content)):
+            logger.warning("Downloaded file from %s is not a valid ZIP, skipping", url)
             return 0
+        cached.write_bytes(content)
 
     total = 0
     try:
@@ -147,25 +201,128 @@ def _download_and_parse_zip(
             for name in zf.namelist():
                 if name.lower().endswith((".csv", ".tsv", ".txt")):
                     raw = zf.read(name)
-                    # Try common encodings
+                    # Try common encodings; latin-1 always succeeds so no else needed
                     for enc in ("utf-8-sig", "utf-8", "latin-1"):
                         try:
                             text = raw.decode(enc)
                             break
                         except UnicodeDecodeError:
                             continue
-                    else:
-                        text = raw.decode("latin-1")
                     total += _parse_csv_content(text, country_code)
     except zipfile.BadZipFile:
         logger.warning("Bad ZIP file from %s", url)
     return total
 
 
+def _db_path() -> Path:
+    """Return the path for the SQLite cache DB, scoped by NUTS version."""
+    return Path(settings.data_dir) / f"postalcode2nuts_NUTS-{settings.nuts_version}.db"
+
+
+def _db_is_valid(db: Path) -> bool:
+    """Check if the SQLite cache DB exists, matches current version, and is fresh."""
+    if not db.is_file():
+        return False
+    try:
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        try:
+            cur = con.execute("SELECT key, value FROM metadata")
+            meta = dict(cur.fetchall())
+        finally:
+            con.close()
+        if meta.get("nuts_version") != settings.nuts_version:
+            logger.info("DB cache version mismatch, will rebuild")
+            return False
+        if int(meta.get("entry_count", "0")) == 0:
+            logger.info("DB cache is empty, will rebuild")
+            return False
+        created = datetime.fromisoformat(meta["created_at"])
+        age_days = (datetime.now(timezone.utc) - created).total_seconds() / 86400
+        if age_days > settings.db_cache_ttl_days:
+            logger.info("DB cache expired (%.0f days old), will rebuild", age_days)
+            return False
+        return True
+    except Exception as exc:
+        logger.info("DB cache unusable (%s), will rebuild", exc)
+        return False
+
+
+def _load_from_db(db: Path) -> bool:
+    """Load the lookup table from SQLite cache. Returns True on success."""
+    try:
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        try:
+            rows = con.execute(
+                "SELECT country_code, postal_code, nuts3 FROM lookup"
+            ).fetchall()
+        finally:
+            con.close()
+        if not rows:
+            return False
+        for cc, pc, nuts3 in rows:
+            _lookup[(cc, pc)] = nuts3
+        logger.info("Loaded %d entries from SQLite cache %s", len(rows), db.name)
+        return True
+    except Exception as exc:
+        logger.warning("Failed to load from DB cache: %s", exc)
+        _lookup.clear()
+        return False
+
+
+def _save_to_db(db: Path) -> None:
+    """Persist the lookup table to SQLite cache with atomic rename."""
+    tmp = db.with_suffix(".db.tmp")
+    try:
+        tmp.unlink(missing_ok=True)
+        con = sqlite3.connect(str(tmp))
+        try:
+            con.execute(
+                "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+            )
+            con.execute(
+                "CREATE TABLE lookup ("
+                "country_code TEXT NOT NULL, "
+                "postal_code TEXT NOT NULL, "
+                "nuts3 TEXT NOT NULL, "
+                "PRIMARY KEY (country_code, postal_code))"
+            )
+            con.executemany(
+                "INSERT INTO lookup (country_code, postal_code, nuts3) VALUES (?, ?, ?)",
+                [(cc, pc, nuts3) for (cc, pc), nuts3 in _lookup.items()],
+            )
+            con.executemany(
+                "INSERT INTO metadata (key, value) VALUES (?, ?)",
+                [
+                    ("nuts_version", settings.nuts_version),
+                    ("created_at", datetime.now(timezone.utc).isoformat()),
+                    ("entry_count", str(len(_lookup))),
+                ],
+            )
+            con.commit()
+        finally:
+            con.close()
+        tmp.replace(db)
+        logger.info("Saved %d entries to SQLite cache %s", len(_lookup), db.name)
+    except Exception as exc:
+        logger.warning("Failed to save DB cache: %s", exc)
+        tmp.unlink(missing_ok=True)
+
+
 def load_data() -> None:
     """Download all TERCET flat files and build the in-memory lookup table."""
     _lookup.clear()
-    cache_dir = Path(settings.data_dir)
+
+    # Ensure data directory exists
+    data_dir = Path(settings.data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fast path: load from SQLite cache if valid
+    db = _db_path()
+    if _db_is_valid(db) and _load_from_db(db):
+        return
+
+    _lookup.clear()
+    cache_dir = data_dir / f"NUTS-{settings.nuts_version}"
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     base_url = settings.tercet_base_url
@@ -191,30 +348,28 @@ def load_data() -> None:
                     loaded_countries.add(cc)
                     logger.info("Loaded %d entries for %s", count, cc)
 
-        # Strategy 2: for countries not yet loaded, try guessed URLs
+        # Strategy 2: for countries not yet loaded, try guessed URLs per-country
         remaining = [c for c in countries if c not in loaded_countries]
         if remaining:
             logger.info(
                 "Trying guessed URLs for %d remaining countries", len(remaining)
             )
-            guessed = _guess_zip_urls(base_url, remaining)
-            for url in guessed:
-                m = re.search(r"pc\d{4}_([A-Z]{2})_", url)
-                if not m:
-                    continue
-                cc = m.group(1)
-                if cc in loaded_countries:
-                    continue
-                count = _download_and_parse_zip(client, url, cc, cache_dir)
-                if count > 0:
-                    loaded_countries.add(cc)
-                    logger.info("Loaded %d entries for %s", count, cc)
+            for cc in remaining:
+                for url in _guess_zip_urls_for_country(base_url, cc):
+                    count = _download_and_parse_zip(client, url, cc, cache_dir)
+                    if count > 0:
+                        loaded_countries.add(cc)
+                        logger.info("Loaded %d entries for %s", count, cc)
+                        break
 
     logger.info(
         "Data loading complete: %d postal codes across %d countries",
         len(_lookup),
         len(loaded_countries),
     )
+
+    if _lookup:
+        _save_to_db(db)
 
 
 def lookup(country_code: str, postal_code: str) -> dict | None:


### PR DESCRIPTION
SQLite cache eliminates re-parsing TERCET CSVs on every startup (~1s vs ~30-60s). The DB is version-scoped, TTL-checked, and written atomically via temp file + rename. If the TERCET server is down, a valid cached DB ensures the service still starts with data.

Also improves data loading robustness: CSV dialect auto-detection via Sniffer, NUTS3 code format validation, download retries on transient errors, per-country URL guessing (stops early on first hit), ZIP integrity checks on cached files, and cache TTL expiry for stale ZIPs.

Data dir default changed from /tmp to ./data (resolves to /app/data in Docker) so cached files live alongside the app for easier maintenance.