### PR TITLE
fix: catch csv.Error in estimate CSV loading

### DIFF
--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -496,7 +496,7 @@ def _load_estimates_from_csv(csv_path: Path) -> bool:
         if count:
             logger.info("Loaded %d estimates from %s", count, csv_path)
         return count > 0
-    except (OSError, KeyError, ValueError) as exc:
+    except (OSError, KeyError, ValueError, csv.Error) as exc:
         logger.warning("Failed to load estimates from CSV: %s", exc)
         return False
 


### PR DESCRIPTION
## Summary

- Add `csv.Error` to the exception tuple in `_load_estimates_from_csv()` to restore graceful degradation for malformed CSV files

Without this, a corrupt estimates CSV (NUL bytes, parser-level corruption) would bubble up and crash startup instead of logging a warning and continuing without estimates. Flagged by Codex review on PR #27.

## Test plan

- [x] `pytest tests/ -v` — 69 tests pass
- [x] `ruff check app/` — passes