### PR TITLE
docs: add testing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Iceland (IS), Liechtenstein (LI), Norway (NO), Switzerland (CH)
 **EU candidate countries** (3):
 North Macedonia (MK), Serbia (RS), Türkiye (TR)
 
+## Testing
+
+The service has been tested against **134 million real-world postal codes** from 34 countries, sourced from 8 publicly available European datasets: GeoNames, GLEIF, TED, SIRENE, OffeneRegister, FTS, OpenAddresses, and Erasmus+ ECHE. All are open data published under permissive licenses (CC BY 4.0, CC0, or Licence Ouverte v2.0).
 
 ## Quick start
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ ruff>=0.7,<1
 bandit>=1.7,<2
 pip-audit>=2,<3
 pytest>=8,<9
+openpyxl>=3,<4


### PR DESCRIPTION
## Summary
- Add Testing section to README describing validation against 134M real-world postal codes from 8 public European datasets
- Add `openpyxl>=3,<4` to `requirements-dev.txt` for XLSX parsing in analysis scripts