### PR TITLE
docs: add bulk test success rate to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ North Macedonia (MK), Serbia (RS), Türkiye (TR)
 
 ## Testing
 
-The service has been tested against **134 million real-world postal codes** from 34 countries, sourced from 8 publicly available European datasets: GeoNames, GLEIF, TED, SIRENE, OffeneRegister, FTS, OpenAddresses, and Erasmus+ ECHE. All are open data published under permissive licenses (CC BY 4.0, CC0, or Licence Ouverte v2.0).
+The service has been tested against **134 million real-world postal codes** from 34 countries, sourced from 8 publicly available European datasets (GeoNames, OpenAddresses, GLEIF, SIRENE, TED, OffeneRegister, FTS, and Erasmus+ ECHE). All are open data published under permissive licenses (CC BY 4.0, CC0, or Licence Ouverte v2.0).
+
+After deduplication, **970,083 unique postal codes** were tested with an overall success rate of **99.3%**. The remaining failures are predominantly data quality issues in the source datasets (placeholders, cross-country codes, legacy formats) rather than gaps in NUTS coverage.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- Add 99.3% success rate from bulk testing 134M postal codes (970K unique) to the Testing section of the README

## Test plan
- [ ] Verify README renders correctly on GitHub