### PR TITLE
chore(ci): bump docker/login-action from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- Bumps `docker/login-action` from v3 to v4 (Node 24 runtime, requires Actions Runner v2.327.1+)

## Test plan
- [ ] CI passes with updated action