### PR TITLE
ci: skip CI checks for docs and data-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '**.csv'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '**.csv'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `paths-ignore` filters for `**.md` and `**.csv` to the CI workflow
- PRs that only touch documentation or data files (e.g. `tercet_missing_codes.csv`) will no longer trigger lint, test, security, and docker checks

## Motivation
This paves the way for data-only contributions (like adding missing postal code records) without waiting for unrelated CI jobs.

Closes #41

## Test plan
- [ ] Verify that a PR touching only `.md` or `.csv` files does not trigger CI
- [ ] Verify that a PR touching `.py` files still triggers the full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)