### PR TITLE
deps: pin python-dotenv >=1.2.2 (CVE-2026-28684)

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -15,7 +15,7 @@ idna==3.11
 limits==5.8.0
 pydantic==2.12.5
 pydantic-settings==2.13.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 PyYAML==6.0.1
 slowapi==0.1.9
 starlette==0.52.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ httpx>=0.27,<1
 pydantic>=2,<3
 pydantic-settings>=2,<3
 slowapi>=0.1,<1
+python-dotenv>=1.2.2,<2


### PR DESCRIPTION
## Summary
- Pins transitive dependency `python-dotenv` to `>=1.2.2,<2` to fix CVE-2026-28684.
- Currently being resolved to `1.0.1` via `pydantic-settings` / `uvicorn[standard]`; pip-audit started flagging this and is blocking the open dependabot PRs.

## Test plan
- [ ] CI `security` job passes (pip-audit clean)
- [ ] Other CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)