### PR TITLE
fix(estimates_refresh): serialize concurrent refreshes (#44 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **Concurrency: refreshes now serialised** (#44 follow-up): added a module-level `asyncio.Lock` around `refresh_estimates_once`. Without it, two overlapping calls (the periodic task and the admin endpoint) could resolve their fetches in non-monotonic order and overwrite newer state with older content. Codex flagged the race on the original PR (#72); fix is internal, no API change.
 - **`scripts/perf_test.sh` `run_warm`**: indexing the vegeta target file by raw line number landed on a blank line half the time, crashing the script under `set -e`. Now extracts only the GET URLs into an array first.
 - **`__version__` was stale at `0.14.0`** since the v0.14 release; openapi.json and FastAPI's `version` field have been reporting the wrong number for every release since then. Bumped to `0.18.0`. Future releases need to update `app/__init__.py` alongside the CHANGELOG until version derivation is automated.
 

--- a/app/estimates_refresh.py
+++ b/app/estimates_refresh.py
@@ -33,6 +33,13 @@ _last_etag: Optional[str] = None
 _last_modified: Optional[str] = None
 _stale: Optional[bool] = None  # None when feature disabled
 
+# Serialises concurrent refresh attempts (the periodic loop + the admin
+# endpoint can both invoke refresh_estimates_once on the same event loop).
+# Holding the lock across `await fetch_remote_csv` is intentional — without
+# that, two parallel fetches could complete in non-monotonic order and the
+# older response would overwrite newer state.
+_refresh_lock: asyncio.Lock = asyncio.Lock()
+
 
 @dataclass
 class RefreshResult:
@@ -89,9 +96,11 @@ async def refresh_estimates_once(
 ) -> RefreshResult:
     """One refresh attempt: fetch, sanity-check, swap.
 
-    When `client` is None, an ephemeral httpx.AsyncClient is created and
-    closed. Production callers (the lifespan loop, the admin endpoint)
-    should pass a long-lived client to reuse connections.
+    Concurrent calls are serialised by `_refresh_lock` so the post-fetch
+    swap can't overwrite a newer state with older content. When `client` is
+    None, an ephemeral httpx.AsyncClient is created and closed. Production
+    callers (the lifespan loop, the admin endpoint) should pass a long-lived
+    client to reuse connections.
     """
     global _last_hash, _last_etag, _last_modified, _stale
 
@@ -104,101 +113,107 @@ async def refresh_estimates_once(
             new_count=previous_count,
         )
 
-    own_client = client is None
-    if own_client:
-        client = httpx.AsyncClient()
-    try:
-        body, status, headers = await fetch_remote_csv(client)
-    finally:
+    async with _refresh_lock:
+        # Recompute previous_count under the lock so the result reflects the
+        # state we're actually transitioning from (a previous concurrent call
+        # may have just finished and changed _estimates while we were waiting).
+        previous_count = len(_estimates)
+
+        own_client = client is None
         if own_client:
-            await client.aclose()
+            client = httpx.AsyncClient()
+        try:
+            body, status, headers = await fetch_remote_csv(client)
+        finally:
+            if own_client:
+                await client.aclose()
 
-    # 304 Not Modified — content unchanged, refresh succeeded
-    if status == 304:
-        _stale = False
-        return RefreshResult(
-            status="unchanged",
-            previous_count=previous_count,
-            new_count=previous_count,
-        )
-
-    # Any other non-200 (including transport errors with status=0)
-    if body is None:
-        was_stale_before = _stale is True
-        _stale = True
-        if not was_stale_before:
-            logger.warning(
-                "Remote estimates fetch failed (status=%d); keeping current state",
-                status,
+        # 304 Not Modified — content unchanged, refresh succeeded
+        if status == 304:
+            _stale = False
+            return RefreshResult(
+                status="unchanged",
+                previous_count=previous_count,
+                new_count=previous_count,
             )
-        return RefreshResult(
-            status="failed",
-            previous_count=previous_count,
-            new_count=previous_count,
-            reason=f"http={status}",
-        )
 
-    new_hash = hashlib.sha256(body).hexdigest()
-    if new_hash == _last_hash:
+        # Any other non-200 (including transport errors with status=0)
+        if body is None:
+            was_stale_before = _stale is True
+            _stale = True
+            if not was_stale_before:
+                logger.warning(
+                    "Remote estimates fetch failed (status=%d); keeping current state",
+                    status,
+                )
+            return RefreshResult(
+                status="failed",
+                previous_count=previous_count,
+                new_count=previous_count,
+                reason=f"http={status}",
+            )
+
+        new_hash = hashlib.sha256(body).hexdigest()
+        if new_hash == _last_hash:
+            _stale = False
+            return RefreshResult(
+                status="unchanged",
+                previous_count=previous_count,
+                new_count=previous_count,
+            )
+
+        try:
+            text = body.decode("utf-8-sig")
+            new_dict, skipped = parse_estimates_from_text(text)
+        except (UnicodeDecodeError, ValueError, csv.Error, KeyError) as exc:
+            _stale = True
+            logger.warning("Remote estimates parse failed: %s", exc)
+            return RefreshResult(
+                status="failed",
+                previous_count=previous_count,
+                new_count=previous_count,
+                reason=f"parse: {exc}",
+            )
+
+        if not _passes_sanity_guard(len(new_dict), previous_count):
+            _stale = True
+            logger.warning(
+                "Remote estimates sanity guard rejected swap (new=%d, current=%d)",
+                len(new_dict),
+                previous_count,
+            )
+            return RefreshResult(
+                status="rejected",
+                previous_count=previous_count,
+                new_count=len(new_dict),
+                reason=f"sanity guard: {len(new_dict)} < 50% of {previous_count}",
+            )
+
+        # Swap. _data_lock is a threading.Lock; acquiring it briefly from an async
+        # context is fine — the swap is microseconds.
+        with _data_lock:
+            _estimates.clear()
+            _estimates.update(new_dict)
+            _revalidate_estimates()
+        new_count = len(_estimates)
+
+        _last_hash = new_hash
+        _last_etag = headers.get("etag")
+        _last_modified = headers.get("last-modified")
         _stale = False
-        return RefreshResult(
-            status="unchanged",
-            previous_count=previous_count,
-            new_count=previous_count,
-        )
 
-    try:
-        text = body.decode("utf-8-sig")
-        new_dict, skipped = parse_estimates_from_text(text)
-    except (UnicodeDecodeError, ValueError, csv.Error, KeyError) as exc:
-        _stale = True
-        logger.warning("Remote estimates parse failed: %s", exc)
-        return RefreshResult(
-            status="failed",
-            previous_count=previous_count,
-            new_count=previous_count,
-            reason=f"parse: {exc}",
-        )
-
-    if not _passes_sanity_guard(len(new_dict), previous_count):
-        _stale = True
-        logger.warning(
-            "Remote estimates sanity guard rejected swap (new=%d, current=%d)",
-            len(new_dict),
+        logger.info(
+            "Remote estimates refreshed: %d -> %d (skipped %d rows during parse)",
             previous_count,
+            new_count,
+            skipped,
         )
         return RefreshResult(
-            status="rejected",
+            status="refreshed",
             previous_count=previous_count,
-            new_count=len(new_dict),
-            reason=f"sanity guard: {len(new_dict)} < 50% of {previous_count}",
+            new_count=new_count,
+            skipped_rows=skipped,
         )
-
-    # Swap. _data_lock is a threading.Lock; acquiring it briefly from an async
-    # context is fine — the swap is microseconds.
-    with _data_lock:
-        _estimates.clear()
-        _estimates.update(new_dict)
-        _revalidate_estimates()
-    new_count = len(_estimates)
-
-    _last_hash = new_hash
-    _last_etag = headers.get("etag")
-    _last_modified = headers.get("last-modified")
-    _stale = False
-
-    logger.info(
-        "Remote estimates refreshed: %d -> %d (skipped %d rows during parse)",
-        previous_count,
-        new_count,
-        skipped,
-    )
-    return RefreshResult(
-        status="refreshed",
-        previous_count=previous_count,
-        new_count=new_count,
-        skipped_rows=skipped,
-    )
 
 
 async def refresh_estimates_loop() -> None:

--- a/tests/test_estimates_refresh.py
+++ b/tests/test_estimates_refresh.py
@@ -400,6 +400,103 @@ class TestRefreshLoop:
         assert len(sleeps) >= 2
 
 
+class TestConcurrentRefresh:
+    """Regression tests for the asyncio.Lock that serialises concurrent calls
+    (Codex flagged the race on PR #72)."""
+
+    @pytest.fixture
+    def url(self, monkeypatch):
+        u = "https://example.invalid/tercet.csv"
+        monkeypatch.setattr("app.estimates_refresh.settings", _stub_settings(url=u))
+        return u
+
+    @pytest.fixture
+    def seed_estimates(self):
+        from app.data_loader import _estimates
+
+        _estimates.clear()
+        for i in range(100):
+            _estimates[("DE", f"{10000 + i}")] = {
+                "nuts3": "DE300",
+                "nuts2": "DE30",
+                "nuts1": "DE3",
+                "nuts3_confidence": 0.9,
+                "nuts2_confidence": 0.95,
+                "nuts1_confidence": 0.98,
+            }
+        yield _estimates
+        _estimates.clear()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_are_serialised(self, url, seed_estimates):
+        """Two overlapping refresh_estimates_once() calls must not interleave
+        their fetch+swap sequences. We instrument fetch_remote_csv to record
+        entry/exit timestamps and assert the second call's entry is strictly
+        after the first call's exit."""
+        from app import estimates_refresh
+
+        # Each fetch returns a unique CSV body so we can tell which one wins.
+        def make_csv(tag: str) -> bytes:
+            header = "COUNTRY_CODE,POSTAL_CODE,ESTIMATED_NUTS3,ESTIMATED_NUTS2,ESTIMATED_NUTS1,CONFIDENCE\n"
+            rows = "".join(
+                f"{tag[0].upper()}{tag[1].upper()},{i:05d},XX300,XX30,XX3,high\n"
+                for i in range(80)
+            )
+            return (header + rows).encode("utf-8")
+
+        events: list[tuple[str, str]] = []  # [(tag, "enter"|"exit"), ...]
+        responses = {"a": make_csv("aa"), "b": make_csv("bb")}
+        next_tag = ["a"]
+
+        async def instrumented_fetch(client):
+            tag = next_tag[0]
+            next_tag[0] = "b"
+            events.append((tag, "enter"))
+            # Yield twice so the other coroutine has a chance to advance.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            events.append((tag, "exit"))
+            return responses[tag], 200, {"etag": f'W/"{tag}"'}
+
+        original_fetch = estimates_refresh.fetch_remote_csv
+        estimates_refresh.fetch_remote_csv = instrumented_fetch
+        try:
+            results = await asyncio.gather(
+                estimates_refresh.refresh_estimates_once(),
+                estimates_refresh.refresh_estimates_once(),
+            )
+        finally:
+            estimates_refresh.fetch_remote_csv = original_fetch
+
+        # Both calls should have completed without raising.
+        assert len(results) == 2
+        # Order must be: a-enter, a-exit, b-enter, b-exit (strictly nested).
+        assert events == [("a", "enter"), ("a", "exit"), ("b", "enter"), ("b", "exit")], (
+            f"events interleaved: {events}"
+        )
+        # The "b" call sees the "a" hash already set, so depending on whether
+        # the bodies hash differently, b will either swap (different content)
+        # or short-circuit as unchanged. Either is fine — the assertion above
+        # is the real concurrency check.
+
+    @pytest.mark.asyncio
+    async def test_disabled_short_circuit_does_not_take_lock(self, monkeypatch):
+        """The disabled short-circuit returns before acquiring the lock. This
+        test isn't strictly needed for correctness, but documents the
+        intentional placement of the disabled check OUTSIDE async with."""
+        monkeypatch.setattr("app.estimates_refresh.settings", _stub_settings(url=""))
+        from app import estimates_refresh
+
+        # Hold the lock; if disabled-check were inside the lock, this call
+        # would block forever (or until our timeout).
+        async with estimates_refresh._refresh_lock:
+            result = await asyncio.wait_for(
+                estimates_refresh.refresh_estimates_once(), timeout=1.0
+            )
+
+        assert result.status == "disabled"
+
+
 def _stub_settings(*, url: str = "", interval: int = 86400):
     """Build a minimal settings stub for tests that only need the two new fields."""
 


### PR DESCRIPTION
Follow-up to #72. Closes the concurrency hole flagged by Codex's review on that PR ([codex comment](https://github.com/bk86a/PostalCode2NUTS/pull/72#discussion_r2533983654) — adjust hash if anchored differently).

## Summary

- Added a module-level `asyncio.Lock` (`_refresh_lock`) and wrapped the body of `refresh_estimates_once` (everything after the disabled short-circuit) in `async with _refresh_lock:`. Serialises the periodic-loop and `POST /admin/refresh-estimates` call paths so two overlapping fetches can't resolve in non-monotonic order and overwrite newer state with older content.
- The lock spans `await fetch_remote_csv(...)` deliberately. Holding it only around the post-fetch portion would not fix the bug, since two parallel fetches could still finish in the wrong order. Holding it across the fetch means an admin call can wait up to ~10 s (the fetch timeout) if a periodic tick is in flight — acceptable for an operator-only endpoint.
- The disabled short-circuit (`if not settings.estimates_refresh_url: return …`) stays *outside* the lock — it's a fast read of a const setting, locking adds nothing, and one of the new tests pins this contract.
- `previous_count` is now recomputed inside the lock so the returned `RefreshResult` reflects the state we're actually transitioning from (relevant if a previous concurrent call just finished).

## Test plan

- [x] Full suite green: 219 tests (217 + 2 new in `TestConcurrentRefresh`)
  - `test_concurrent_calls_are_serialised`: `asyncio.gather` of two `refresh_estimates_once` calls + an instrumented `fetch_remote_csv` that yields with `asyncio.sleep(0)`. Asserts the event ordering is strictly nested (`a-enter, a-exit, b-enter, b-exit`) — without the lock, the events would interleave.
  - `test_disabled_short_circuit_does_not_take_lock`: holds the lock manually from the test and confirms a disabled-feature call still returns immediately under `asyncio.wait_for(..., timeout=1.0)`.
- [x] `ruff check app/ scripts/` clean
- [x] `ruff format --check app/ scripts/` clean
- [ ] After merge: PATCH the deployed api container to the new image so the live worker picks up the lock — same flow as the original #44 deploy (only the imageDigest changes; no env-var change)

## Notes for reviewers

- No API change. The fix is purely internal.
- Practical impact pre-fix was small (24 h periodic + rare admin calls), but it was a real correctness regression, easy to fix, and Codex caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)