### PR TITLE
diag: /admin/memory endpoint for in-process leak investigation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -431,3 +431,90 @@ async def admin_refresh_estimates(request: Request) -> JSONResponse:
             "source_url": settings.estimates_refresh_url,
         },
     )
+
+
+@app.get(
+    "/admin/memory",
+    summary="Memory and runtime diagnostics",
+    description=(
+        "Operator-only — requires `Authorization: Bearer <trusted-token>`. "
+        "Returns sizes of in-memory state, /proc process counters, asyncio task / "
+        "thread / file-descriptor counts, and a `gc.get_objects()` type histogram. "
+        "Intended for one-off leak investigations; safe to call repeatedly but "
+        "the gc walk takes ~hundreds of ms on large heaps."
+    ),
+    include_in_schema=False,
+)
+async def admin_memory(request: Request) -> JSONResponse:
+    if not getattr(request.state, "trusted", False):
+        raise HTTPException(status_code=401, detail="Trusted token required")
+
+    import asyncio
+    import gc
+    import os
+    import threading
+    from collections import Counter
+
+    from app import auth as _auth
+    from app import data_loader as _dl
+    from app.limiter import limiter as _limiter
+
+    sizes: dict[str, int] = {
+        "data_loader._lookup": len(_dl._lookup),
+        "data_loader._estimates": len(_dl._estimates),
+        "data_loader._prefix_index_countries": len(_dl._prefix_index),
+        "data_loader._prefix_index_total_entries": sum(
+            sum(len(v) for v in idx.values()) for idx in _dl._prefix_index.values()
+        ),
+        "data_loader._nuts_names": len(_dl._nuts_names),
+        "data_loader._single_nuts3": len(_dl._single_nuts3),
+        "data_loader._country_fallback": len(_dl._country_fallback),
+        "auth._db_tokens": len(_auth._db_tokens),
+    }
+    storage = getattr(_limiter, "_storage", None)
+    if storage is not None:
+        for attr in ("storage", "expirations", "events", "locks"):
+            d = getattr(storage, attr, None)
+            if d is not None:
+                try:
+                    sizes[f"limiter._storage.{attr}"] = len(d)
+                except TypeError:
+                    pass
+
+    proc: dict[str, str | int] = {}
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                key, _, val = line.partition(":")
+                if key in {"VmRSS", "VmSize", "VmHWM", "RssAnon", "RssFile", "Threads"}:
+                    proc[key] = val.strip()
+    except OSError:
+        pass
+    try:
+        proc["fd_count"] = len(os.listdir("/proc/self/fd"))
+    except OSError:
+        pass
+
+    try:
+        tasks = asyncio.all_tasks()
+        task_info: dict[str, object] = {
+            "count": len(tasks),
+            "sample": sorted({str(t.get_coro())[:160] for t in tasks})[:15],
+        }
+    except RuntimeError:
+        task_info = {"count": -1, "sample": []}
+
+    gc.collect()
+    type_counts = Counter(type(o).__name__ for o in gc.get_objects())
+    top_types = [{"type": t, "count": c} for t, c in type_counts.most_common(30)]
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "sizes": sizes,
+            "proc": proc,
+            "asyncio_tasks": task_info,
+            "thread_count": threading.active_count(),
+            "gc_top_30_types": top_types,
+        },
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -484,3 +484,49 @@ class TestAdminRefreshEstimatesEndpoint:
         body = resp.json()
         assert body["status"] == "rejected"
         assert body["candidate_count"] == 12
+
+
+class TestAdminMemoryEndpoint:
+    def test_401_without_authorization(self, trusted_client):
+        resp = trusted_client.get("/admin/memory")
+        assert resp.status_code == 401
+
+    def test_401_with_invalid_bearer(self, trusted_client):
+        resp = trusted_client.get(
+            "/admin/memory",
+            headers={"Authorization": "Bearer not-a-real-token"},
+        )
+        assert resp.status_code == 401
+
+    def test_200_returns_diagnostic_payload(self, trusted_client):
+        resp = trusted_client.get(
+            "/admin/memory",
+            headers={"Authorization": "Bearer test-token-aaa"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        # Top-level keys present
+        assert set(body.keys()) >= {
+            "sizes",
+            "proc",
+            "asyncio_tasks",
+            "thread_count",
+            "gc_top_30_types",
+        }
+        # Module-scoped sizes are present and integer-valued
+        for key in (
+            "data_loader._lookup",
+            "data_loader._estimates",
+            "data_loader._prefix_index_countries",
+            "auth._db_tokens",
+        ):
+            assert key in body["sizes"]
+            assert isinstance(body["sizes"][key], int)
+        # gc histogram is non-empty
+        assert isinstance(body["gc_top_30_types"], list)
+        assert len(body["gc_top_30_types"]) > 0
+        assert {"type", "count"} <= set(body["gc_top_30_types"][0].keys())
+        # asyncio task info has the expected shape
+        assert "count" in body["asyncio_tasks"]
+        # thread count is at least 1 (the test thread itself)
+        assert body["thread_count"] >= 1


### PR DESCRIPTION
## Summary
- Adds `GET /admin/memory`, trusted-token-gated, returning the levers to localise in-process growth: every module-scoped dict's `len()`, `/proc/self/status` (VmRSS/VmHWM/RssAnon/RssFile/Threads), FD count, asyncio task count + sample, and a top-30 `gc.get_objects()` type histogram.
- `include_in_schema=False` keeps it out of the public OpenAPI doc. Mirrors `/admin/refresh-estimates`'s auth shape (401 without bearer, 200 otherwise).
- Intended as a diagnostic, not a permanent feature — a `gc.get_objects()` walk on a 4 GB heap runs in hundreds of ms, fine for manual snapshots, not a hot path.

## Why
We're investigating a memory growth that began Sat 2 May ~06:00 — pre-deploy baseline was ~810 MB pod RAM (`docs/performance.md:106-116`), now over 4 GB and climbing. Two leading hypotheses (slowapi `MemoryStorage` accumulating per-IP, and the new periodic estimates refresh `swap` path) were both reproduced locally and disproven — `MemoryStorage` evicts properly under sustained traffic; `refresh_estimates_once` stays flat across 200 ticks. Without instrumented snapshots from the running container we'd be guessing.

## Test plan
- [x] `pytest tests/test_api.py::TestAdminMemoryEndpoint` — 3 tests: 401 without token, 401 with invalid bearer, 200 returns the expected payload shape (sizes / proc / asyncio_tasks / thread_count / gc_top_30_types).
- [x] `pytest tests/test_api.py` — 48/48 passing.
- [x] `ruff check app/main.py tests/test_api.py` — clean.
- [ ] After merge + deploy: snapshot once shortly after restart, again 6-12 h later, diff to identify the growing object class.

## Operator usage (post-deploy)
```bash
curl -s https://api.datatoolset.eu/admin/memory \
  -H "Authorization: Bearer <trusted-token>" | jq
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)