### PR TITLE
fix(diag): offload /admin/memory gc walk; drop gc.collect

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -495,6 +495,8 @@ async def admin_memory(request: Request) -> JSONResponse:
     except OSError:
         pass
 
+    # asyncio.all_tasks() must run on the event loop, so capture it before
+    # offloading anything else.
     try:
         tasks = asyncio.all_tasks()
         task_info: dict[str, object] = {
@@ -504,9 +506,17 @@ async def admin_memory(request: Request) -> JSONResponse:
     except RuntimeError:
         task_info = {"count": -1, "sample": []}
 
-    gc.collect()
-    type_counts = Counter(type(o).__name__ for o in gc.get_objects())
-    top_types = [{"type": t, "count": c} for t, c in type_counts.most_common(30)]
+    # The gc.get_objects() walk is the expensive part — on a multi-GB heap it
+    # iterates 10M+ objects. Offload to a thread so the GIL releases between
+    # iterations of the pure-Python Counter loop and other coroutines on this
+    # worker can interleave. gc.collect() is intentionally omitted: on a heap
+    # this size it costs seconds and holds the GIL throughout, while
+    # transient-cycle noise is negligible compared to anything worth diagnosing.
+    def _gc_type_histogram() -> list[dict[str, object]]:
+        type_counts = Counter(type(o).__name__ for o in gc.get_objects())
+        return [{"type": t, "count": c} for t, c in type_counts.most_common(30)]
+
+    top_types = await asyncio.to_thread(_gc_type_histogram)
 
     return JSONResponse(
         status_code=200,


### PR DESCRIPTION
## Summary
Addresses Codex P2 feedback on #75: the `/admin/memory` handler ran `gc.collect()` + `gc.get_objects()` + a Counter loop on the event loop, which on a multi-GB heap can stall the worker for several seconds and queue every other request.

- Move the gc-walk + Counter into `asyncio.to_thread`. The pure-Python iteration releases the GIL between bytecode batches, so other coroutines on the worker interleave instead of waiting for the snapshot.
- Drop `gc.collect()`. On a multi-GB heap collection costs seconds and holds the GIL throughout — no thread offload would help. For leak diagnosis, transient-cycle noise is negligible compared to anything worth chasing.
- `asyncio.all_tasks()` stays inline (must run on the event loop), captured before the offload.

## Why this matters now
The endpoint exists specifically to be hit on the leaking pod (currently >4 GB), where the unfixed version would impose multi-second pauses on every snapshot — exactly the heap state where the blocking is most painful.

## Test plan
- [x] `pytest tests/test_api.py::TestAdminMemoryEndpoint` — 3/3 passing (endpoint contract unchanged).
- [x] `ruff check app/main.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)