### PR TITLE
chore(deps): pin idna>=3.15 to clear CVE-2026-45409

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -11,7 +11,7 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.7.1
 httpx==0.28.1
-idna==3.11
+idna==3.16
 limits==5.8.0
 pydantic==2.12.5
 pydantic-settings==2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pydantic-settings>=2.14.0,<3
 slowapi>=0.1.9,<1
 limits[redis]>=5.8.0
 python-dotenv>=1.2.2,<2
+# Transitive (via httpx); pinned to clear CVE-2026-45409
+idna>=3.15,<4


### PR DESCRIPTION
## What

Pin `idna>=3.15,<4` in `requirements.txt`.

## Why

`idna 3.11` is pulled in transitively (via `httpx`) and is flagged by `pip-audit` as **CVE-2026-45409** (fixed in 3.15). Because `security` is a required status check, this currently fails CI on every open PR (e.g. #85, #86). Dependabot won't open a PR for it since it's an undeclared transitive dependency, so we pin it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)