### PR TITLE
ci: publish on bundled-data changes + workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,9 @@ jobs:
         run: echo "Docs-only change — skipping docker build."
 
   publish:
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
+    # workflow_dispatch on main always publishes (the whole point of a manual
+    # trigger); push to main publishes only if a code-relevant file changed.
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && needs.changes.outputs.code == 'true'))
     needs: [changes, lint, import-check, test, security, docker]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -13,10 +14,14 @@ permissions:
 
 jobs:
   # Detect whether the change touches any code-relevant path.
-  # Docs-only changes (README, *.md, *.csv, docs/**) skip heavy work
-  # while every required check name still reports success — this avoids
-  # the paths-ignore + required-status-checks deadlock that previously
-  # blocked docs-only PRs.
+  # Docs-only changes (README, *.md outside the repo root data files,
+  # docs/**) skip heavy work while every required check name still
+  # reports success — this avoids the paths-ignore + required-status-checks
+  # deadlock that previously blocked docs-only PRs.
+  #
+  # Data files bundled into the container image (tercet_missing_codes.csv,
+  # docker-entrypoint.sh) ARE code-relevant — a change to either affects
+  # what ships in `ghcr.io/.../:latest`, so they belong in the filter.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -36,6 +41,8 @@ jobs:
               - 'pyproject.toml'
               - 'Dockerfile'
               - 'Makefile'
+              - 'docker-entrypoint.sh'
+              - 'tercet_missing_codes.csv'
               - '.github/workflows/**'
 
   lint:
@@ -126,7 +133,7 @@ jobs:
         run: echo "Docs-only change — skipping docker build."
 
   publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
     needs: [changes, lint, import-check, test, security, docker]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Fixes a CI-paths-filter bug that caused PR #93 to merge without triggering a fresh container publish. Two files that the `Dockerfile` `COPY`s into the image were missing from the `changes` filter:

- `tercet_missing_codes.csv` — the bundled estimates fallback table
- `docker-entrypoint.sh` — the actual container `ENTRYPOINT`

A CSV-only or entrypoint-only change should rebuild the image, because both files affect what ships in `ghcr.io/.../:latest`. Adds them to the filter.

Also adds `workflow_dispatch` to the workflow triggers and to the `publish` job's `if` condition, so future manual rebuilds don't require an empty-commit dance.

### Consequence on merge

Triggers a fresh image build that includes #93's CSV update (38 new postcodes + the LT 71205 → LT024 correction). After this merges, `:latest` will carry both the v0.19.3 deps and the latest data.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `gh run list --workflow ci.yml --branch main --limit 1` shows the `publish` job ran (not skipped)
- [ ] `ghcr.io/bk86a/PostalCode2NUTS:latest` points at the new SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)