### PR TITLE
chore(deps): bundle Dependabot bumps + clear starlette CVE

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-ruff>=0.15.14,<1
+ruff>=0.15.17,<1
 bandit>=1.9.4,<2
-pip-audit>=2.10.0,<3
-pytest>=9.0.3,<10
+pip-audit>=2.10.1,<3
+pytest>=9.1.0,<10
 pytest-asyncio>=1.4.0,<2

--- a/requirements.lock
+++ b/requirements.lock
@@ -3,16 +3,16 @@
 #   pip install -r requirements.txt && pip freeze > requirements.lock
 annotated-doc==0.0.4
 annotated-types==0.7.0
-anyio==4.13.0
-certifi==2026.5.20
+anyio==4.14.0
+certifi==2026.6.17
 click==8.4.1
 Deprecated==1.3.1
-fastapi==0.136.3
+fastapi==0.137.2
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.8.0
 httpx==0.28.1
-idna==3.16
+idna==3.18
 limits==5.8.0
 packaging==26.2
 pydantic==2.13.4
@@ -20,12 +20,12 @@ pydantic-settings==2.14.1
 pydantic_core==2.46.4
 python-dotenv==1.2.2
 PyYAML==6.0.3
-redis==7.4.0
-slowapi==0.1.9
-starlette==1.1.0
+redis==7.4.1
+slowapi==0.1.10
+starlette==1.3.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
-uvicorn==0.48.0
+uvicorn==0.49.0
 uvloop==0.22.1
 watchfiles==1.2.0
 websockets==16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi>=0.136.3,<1
-uvicorn[standard]>=0.48.0,<1
+uvicorn[standard]>=0.49.0,<1
 httpx>=0.28.1,<1
 pydantic>=2.13.4,<3
 pydantic-settings>=2.14.1,<3
@@ -7,4 +7,4 @@ slowapi>=0.1.9,<1
 limits[redis]>=5.8.0
 python-dotenv>=1.2.2,<2
 # Transitive (via httpx); pinned to clear CVE-2026-45409
-idna>=3.16,<4
+idna>=3.18,<4

--- a/tests/test_estimates_refresh.py
+++ b/tests/test_estimates_refresh.py
@@ -3,7 +3,6 @@
 import asyncio
 import hashlib
 import importlib
-from unittest.mock import patch
 
 import httpx
 import pytest


### PR DESCRIPTION
Bundles the five open Dependabot PRs into one branch and regenerates the production lockfile. The regen floats `starlette` 1.1.0 → 1.3.1, clearing **CVE-2026-54282 / CVE-2026-54283** — the advisory currently breaking the `security` gate on #101/#102 (and which would break #96/#98/#99 on re-run).

### Manifest bumps
| PR | Dep | Change |
|----|-----|--------|
| #96 | uvicorn | `>=0.48.0` → `>=0.49.0` |
| #98 | idna | `>=3.16` → `>=3.18` |
| #99 | pip-audit (dev) | `>=2.10.0` → `>=2.10.1` |
| #101 | pytest (dev) | `>=9.0.3` → `>=9.1.0` |
| #102 | ruff (dev) | `>=0.15.14` → `>=0.15.17` |

### Lockfile float-ups (transitive)
`anyio` 4.14.0 · `certifi` 2026.6.17 · `fastapi` 0.137.2 · `redis` 7.4.1 · `slowapi` 0.1.10 · **`starlette` 1.3.1**

### Notes
- The ruff bump surfaces a pre-existing unused import in `tests/test_estimates_refresh.py`; removed to keep lint green.
- `pip-audit -r requirements.lock` → no known vulnerabilities. 222 tests pass locally.

Closes #96, closes #98, closes #99, closes #101, closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)