### PR TITLE
fix(eval): accept COUNTRY_CODE/POSTAL_CODE headers in query reader

### DIFF
--- a/scripts/evaluate_pip_mapping.py
+++ b/scripts/evaluate_pip_mapping.py
@@ -107,11 +107,28 @@ def format_report(summary: dict) -> str:
     return "\n".join(lines)
 
 
+# Accept the query-log headers (COUNTRY/POST_CODE) and the repo's estimate/data
+# headers (COUNTRY_CODE/POSTAL_CODE), plus common variants.
+_COUNTRY_ALIASES = ("COUNTRY", "COUNTRY_CODE", "CC")
+_POSTCODE_ALIASES = ("POST_CODE", "POSTAL_CODE", "POSTCODE")
+
+
+def _pick_column(cols: dict[str, str], aliases: tuple[str, ...], kind: str) -> str:
+    for alias in aliases:
+        if alias in cols:
+            return cols[alias]
+    raise ValueError(
+        f"input CSV is missing a {kind} column: expected one of "
+        f"{', '.join(aliases)}; found {', '.join(cols) or '(no header row)'}"
+    )
+
+
 def _read_query_rows(path: str) -> Iterator[tuple[str, str]]:
     with open(path, encoding="utf-8-sig", newline="") as fh:
         reader = csv.DictReader(fh)
         cols = {c.upper(): c for c in reader.fieldnames or []}
-        cc_col, pc_col = cols["COUNTRY"], cols["POST_CODE"]
+        cc_col = _pick_column(cols, _COUNTRY_ALIASES, "country")
+        pc_col = _pick_column(cols, _POSTCODE_ALIASES, "postal-code")
         for row in reader:
             yield row[cc_col].strip(), row[pc_col].strip()
 

--- a/tests/test_evaluate_pip_mapping.py
+++ b/tests/test_evaluate_pip_mapping.py
@@ -98,3 +98,34 @@ def test_evaluate_normalizes_query_country_for_coord_lookup():
     buckets = {(r["country"], r["postcode"]): r["bucket"] for r in recs}
     assert buckets[("GR", "10431")] == "rescue"  # GR reconciled to EL coord
     assert buckets[("EL", "10431")] == "rescue"
+
+
+def _write_csv(path, header, rows):
+    import csv as _csv
+
+    with open(path, "w", newline="") as fh:
+        w = _csv.writer(fh)
+        w.writerow(header)
+        w.writerows(rows)
+
+
+def test_read_query_rows_accepts_query_log_headers(tmp_path):
+    p = tmp_path / "q.csv"
+    _write_csv(p, ["COUNTRY", "POST_CODE"], [["DE", "10115"], ["fr", " 75001 "]])
+    assert list(ev._read_query_rows(str(p))) == [("DE", "10115"), ("fr", "75001")]
+
+
+def test_read_query_rows_accepts_estimate_data_headers(tmp_path):
+    # tercet_missing_codes.csv uses COUNTRY_CODE / POSTAL_CODE.
+    p = tmp_path / "d.csv"
+    _write_csv(p, ["COUNTRY_CODE", "POSTAL_CODE", "ESTIMATED_NUTS3"], [["AL", "1001", "AL011"]])
+    assert list(ev._read_query_rows(str(p))) == [("AL", "1001")]
+
+
+def test_read_query_rows_missing_column_raises_clear_error(tmp_path):
+    import pytest
+
+    p = tmp_path / "bad.csv"
+    _write_csv(p, ["NATION", "ZIP"], [["DE", "10115"]])
+    with pytest.raises(ValueError, match="missing a country column"):
+        list(ev._read_query_rows(str(p)))


### PR DESCRIPTION
`_read_query_rows` in `scripts/evaluate_pip_mapping.py` hard-required `COUNTRY`/`POST_CODE` and raised a bare `KeyError` on any other header — including the repo's own `tercet_missing_codes.csv` (`COUNTRY_CODE`/`POSTAL_CODE`). Flagged by Codex on #119.

## Changes
- Accept `COUNTRY_CODE`/`POSTAL_CODE` (and `CC`/`POSTCODE`) aliases
- Raise a clear `ValueError` naming expected-vs-found columns instead of `KeyError`
- Tests for both header styles + the missing-column error path (8/8 pass)