### PR TITLE
Publish /resolve geocoding tier + Lite/Full deployment docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ local-data/
 
 # Git worktrees for in-flight feature branches
 .worktrees/
+
+# Private planning / SDD artifacts — infra context + operator token; never commit or push
+docs/superpowers/
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,31 @@ Faroe Islands (FO) — not part of NUTS; synthetic result.
 
 > **Faroe Islands** is an autonomous Danish territory with no NUTS coverage and no GISCO TERCET file. Lookups for FO are served by a synthetic single-region fallback (Tier 6) configured via `synthetic_nuts_fallback` in `app/settings.json`, returning `FO0` / `FO00` / `FO000` with `match_type="approximate"` and capped confidence (`0.90` / `0.85` / `0.80`) for any well-formed 3-digit code. The code is fabricated, not derived from a real NUTS dataset — contrast Montenegro's `ME000`, which is a genuine single-region NUTS code.
 
+## Deployment tiers
+
+PostalCode2NUTS runs in one of two tiers, chosen at deploy time by a single config
+value — one codebase, one image.
+
+| | **Lite** (default) | **Full** |
+|---|---|---|
+| Selected by | `PC2NUTS_PHOTON_URL` unset | `PC2NUTS_PHOTON_URL` set |
+| Resolution | postal code → NUTS (5-tier) | postal → NUTS, then address → geocode → NUTS fallback |
+| Endpoints | `/lookup`, `/pattern`, `/health`, `/resolve`\* | same, with `/resolve` geocoding active |
+| Extra infrastructure | none | komoot Photon + NUTS-2024 polygons (~160 MB, auto-cached) |
+| Footprint | ~35 MB data | ~100× (dominated by the Photon index) |
+| Best for | high throughput, low cost, exact postal coverage | maximum coverage, messy/partial addresses |
+
+\* In Lite, `/resolve` still answers but only from the postal path; its
+`geocode.status` is `geocoder_unavailable`. `GET /health` reports `pip_ready` and
+`geocoder_configured` so you can confirm the active tier.
+
+**Why Full?** On a 900k-row real-world dataset the geocoding fallback resolves an
+extra **~8.5%** of rows that postal lookup alone cannot — and up to **~33%** in
+countries with weak postal→NUTS coverage (Netherlands, Malta, Ireland).
+
+Lite is the default and needs nothing beyond the base image. To enable Full, see
+[Full tier](#full-tier) below.
+
 ## Testing
 
 The service has been tested against **134 million real-world postal codes** from 34 countries, sourced from 8 publicly available European datasets (GeoNames, OpenAddresses, GLEIF, SIRENE, TED, OffeneRegister, FTS, and Erasmus+ ECHE). All are open data published under permissive licenses (CC BY 4.0, CC0, or Licence Ouverte v2.0).
@@ -47,6 +72,41 @@ docker run -p 8000:8000 postalcode2nuts
 ```
 
 See [Docker deployment](#docker-deployment) below for persistent volumes and production configuration.
+
+### Full tier
+
+The Full tier adds an address → coordinate → NUTS fallback for rows the postal path
+can't resolve. It needs two things beyond Lite:
+
+1. **A komoot Photon geocoder.** Photon serves an OpenStreetMap-derived index. You
+   can build/download either the full planet index (~89 GB) or a smaller
+   country-subset extract — pick what matches the countries you serve. Run it bound
+   to loopback and point the app at it:
+
+   ```bash
+   # Obtain photon.jar and an index directory (see https://github.com/komoot/photon),
+   # then serve it:
+   java -jar photon.jar serve -data-dir /path/to/photon -listen-ip 127.0.0.1 -listen-port 2322
+   ```
+
+2. **NUTS polygons.** On first Full-tier startup the app downloads the GISCO
+   NUTS-2024 (1:1M) polygons into `PC2NUTS_DATA_DIR` and caches them. To avoid the
+   download, pre-seed the file and set `PC2NUTS_NUTS_GEOJSON_PATH`.
+
+Enable Full mode by setting `PC2NUTS_PHOTON_URL`. With Docker Compose:
+
+```bash
+docker compose -f compose.yaml -f compose.full.yaml up -d
+```
+
+Confirm the tier is live:
+
+```bash
+curl -s localhost:8000/health | jq '{pip_ready, geocoder_configured}'
+# → {"pip_ready": true, "geocoder_configured": true}
+```
+
+Addresses are sent to your Photon instance only; they are never logged.
 
 ## Endpoints
 
@@ -160,6 +220,42 @@ GET /pattern?country=AT
   "example": "1010, A-1010, AT-1010"
 }
 ```
+
+### `GET /resolve`
+
+Full tier. Resolves NUTS with a geocoding fallback: it runs the postal lookup first
+and, only when that result is weak (`not_found`, or `nuts3_confidence` below
+`PC2NUTS_RESOLVE_CONFIDENCE_THRESHOLD`, default `0.85`) **and** a street/city was
+supplied, geocodes the address via Photon and maps the coordinate to a NUTS-3 region
+by point-in-polygon. A geocode that lands just outside a (generalized) polygon is
+snapped to the nearest same-country region within `PC2NUTS_PIP_SNAP_KM` (default
+`2.0` km); cross-country snapping is refused.
+
+**Query parameters:** `country` (2-letter, required), `postal_code` (required),
+`street` (optional), `city` (optional).
+
+```bash
+curl -s "localhost:8000/resolve?country=NL&postal_code=1012AB&street=Dam&city=Amsterdam"
+```
+
+**Response fields:** `country_code`, `postal_code`, `resolved_via`
+(`postal` | `geocode` | `none`), `match_type`, `nuts1..nuts3` (+ `_name`),
+`nuts3_confidence`, and a `geocode` object: `status`, `lat`, `lon`, `nuts3`,
+`snap_km`.
+
+`geocode.status` values:
+
+| status | meaning |
+|---|---|
+| `not_attempted` | postal result was strong enough; geocoding skipped |
+| `ok` | geocoded and the point fell inside a NUTS-3 region |
+| `snapped` | point was just outside; snapped to the nearest same-country region (`snap_km`) |
+| `pip_outside` | geocoded but the point is outside all NUTS regions and beyond the snap cap |
+| `no_result` | the geocoder found no coordinate |
+| `no_address` | postal result was weak but no street/city was supplied |
+| `geocoder_unavailable` | Lite tier — no geocoder configured |
+
+In Lite, `/resolve` returns the postal result with `geocode.status: geocoder_unavailable`.
 
 ### `GET /health`
 
@@ -335,6 +431,11 @@ All settings are overridable via environment variables prefixed with `PC2NUTS_`:
 | `PC2NUTS_ACCESS_LOG_BACKUP_COUNT` | `5` | Number of rotated access log files to keep (e.g. 5 x 10 MB = 50 MB max disk usage). |
 | `PC2NUTS_ESTIMATES_REFRESH_URL` | *(empty — feature disabled)* | When set, the worker periodically fetches this URL and replaces the in-memory estimates table. Recommended value: `https://raw.githubusercontent.com/bk86a/PostalCode2NUTS/main/tercet_missing_codes.csv`. |
 | `PC2NUTS_ESTIMATES_REFRESH_INTERVAL_SECONDS` | `86400` (24 h) | How often the periodic task fetches the URL. Set to `0` to disable the periodic loop while keeping the bootstrap fetch on startup. |
+| `PC2NUTS_PHOTON_URL` | _(unset)_ | Photon geocoder base URL. **Unset ⇒ Lite tier.** Set ⇒ Full tier. |
+| `PC2NUTS_NUTS_GEOJSON_URL` | GISCO NUTS-2024 1M zip | Source for NUTS polygons (Full tier); auto-downloaded + cached. |
+| `PC2NUTS_NUTS_GEOJSON_PATH` | _(unset)_ | Pre-seeded polygon file; skips the download when set. |
+| `PC2NUTS_RESOLVE_CONFIDENCE_THRESHOLD` | `0.85` | Geocode only when the postal `nuts3_confidence` is below this. |
+| `PC2NUTS_PIP_SNAP_KM` | `2.0` | Max distance to snap a just-outside point to the nearest same-country NUTS-3 region. `0` disables snapping. |
 
 ### Multi-worker deployment
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Addresses are sent to your Photon instance only; they are never logged.
 | `GET /pattern` | Get the postal code regex pattern for a country |
 | `GET /health` | Health check with data statistics |
 
-Interactive API docs are available at `/docs` (Swagger UI) and `/redoc`. To disable in production, set `PC2NUTS_DOCS_ENABLED=false`.
+Interactive API docs are available at `/documentation` (Swagger UI) and `/redoc`. To disable in production, set `PC2NUTS_DOCS_ENABLED=false`.
 
 ### `GET /lookup`
 
@@ -424,7 +424,8 @@ All settings are overridable via environment variables prefixed with `PC2NUTS_`:
 | `PC2NUTS_TOKEN_DB_URL` | `""` (unset) | Connection string for the trusted-token database. Accepts both `https://…` and `libsql://…` (the latter is rewritten to `https://` automatically). Empty → DB-backed bypass disabled, falls back to env-var-only behaviour. |
 | `PC2NUTS_TOKEN_DB_AUTH_TOKEN` | `""` (unset) | Bearer JWT presented to the trusted-token database. Required when the provider enforces auth. |
 | `PC2NUTS_TOKEN_REFRESH_SECONDS` | `60` (min `1`) | How often the running service reloads the active trusted-token set from the DB. |
-| `PC2NUTS_DOCS_ENABLED` | `true` | Set to `false` to disable Swagger UI (`/docs`) and ReDoc (`/redoc`) in production. |
+| `PC2NUTS_DOCS_ENABLED` | `true` | Set to `false` to disable Swagger UI (`/documentation`) and ReDoc (`/redoc`) in production. |
+| `PC2NUTS_DOCS_URL` | `/documentation` | Path for the interactive API docs UI. |
 | `PC2NUTS_CORS_ORIGINS` | `*` | Comma-separated list of allowed CORS origins. Set to a specific origin (e.g. `https://example.com`) to restrict cross-origin access. Empty string disables CORS middleware. |
 | `PC2NUTS_ACCESS_LOG_FILE` | *(empty — stdout)* | Path to access log file. When set, logs are written to this file with automatic rotation. When empty, access logs go to stderr. |
 | `PC2NUTS_ACCESS_LOG_MAX_MB` | `10` | Maximum size of each access log file in MB before rotation. |

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,14 @@ class Settings(BaseSettings):
     cache_max_age: int = _defaults.get("cache_max_age", 3600)
     startup_timeout: int = 300
     docs_enabled: bool = True
+    photon_url: str = ""
+    photon_timeout_seconds: float = 5.0
+    nuts_geojson_url: str = (
+        "https://gisco-services.ec.europa.eu/distribution/v2/nuts/download/ref-nuts-2024-01m.geojson.zip"
+    )
+    nuts_geojson_path: str = ""
+    resolve_confidence_threshold: float = Field(default=0.85, ge=0.0, le=1.0)
+    docs_url: str = "/documentation"
     cors_origins: str = "*"
     access_log_file: str = ""
     access_log_max_mb: int = 10

--- a/app/config.py
+++ b/app/config.py
@@ -38,6 +38,10 @@ class Settings(BaseSettings):
     )
     nuts_geojson_path: str = ""
     resolve_confidence_threshold: float = Field(default=0.85, ge=0.0, le=1.0)
+    # Max distance (km) to snap a geocoded point that fell just outside every NUTS
+    # polygon to the nearest same-country NUTS-3 region (coastline/border rescue).
+    # 0 disables snapping.
+    pip_snap_km: float = Field(default=2.0, ge=0.0)
     docs_url: str = "/documentation"
     cors_origins: str = "*"
     access_log_file: str = ""

--- a/app/main.py
+++ b/app/main.py
@@ -435,6 +435,7 @@ def resolve_endpoint(
         pip=_nuts_pip,
         name_fn=lambda code: get_nuts_names().get(code),
         threshold=settings.resolve_confidence_threshold,
+        snap_km=settings.pip_snap_km,
     )
     # /resolve carries PII → do not cache.
     response.headers["Cache-Control"] = "no-store"

--- a/app/main.py
+++ b/app/main.py
@@ -33,14 +33,33 @@ from app.data_loader import (
     lookup,
     normalize_country,
 )
-from app.models import ErrorResponse, HealthResponse, NUTSResult, PatternResponse
+from app.models import (
+    ErrorResponse,
+    HealthResponse,
+    NUTSResult,
+    PatternResponse,
+    ResolveResponse,
+)
+from app.nuts_polygons import load_nuts_pip
+from app.photon_client import PhotonClient
 from app.postal_patterns import PATTERNS_META, POSTAL_PATTERNS
+from app.resolver import resolve as _resolve
+import httpx as _httpx
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# httpx logs full outbound request URLs (including query strings) at INFO.
+# /resolve sends street/city to the Photon geocoder as query params, so at
+# INFO level httpx would leak that PII into our logs — quiet it to WARNING.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+_nuts_pip = None  # app.nuts_pip.NutsPip once polygons load
+_photon_client = None  # app.photon_client.PhotonClient when PC2NUTS_PHOTON_URL set
+_geo_http: _httpx.Client | None = None
 
 # Access logger — separate from app logger.
 # Propagates to the root logger so pytest caplog can capture records.
@@ -97,6 +116,26 @@ async def lifespan(app: FastAPI):
         logger.info("Extra data sources configured: %d", extra)
     if get_data_stale():
         logger.warning("Serving STALE data — TERCET refresh failed, using expired cache")
+
+    # ── NUTS polygons + geocoder for /resolve (#resolve-endpoint) ───────────
+    global _nuts_pip, _photon_client, _geo_http
+    try:
+        _nuts_pip = load_nuts_pip(
+            url=settings.nuts_geojson_url,
+            path=settings.nuts_geojson_path,
+            cache_dir=settings.data_dir,
+            client=_httpx.Client(),
+        )
+        logger.info("NUTS polygons loaded — /resolve PIP ready.")
+    except Exception:
+        logger.exception("NUTS polygon load failed — /resolve will serve postal-only")
+        _nuts_pip = None
+    if _config.settings.photon_url:
+        _geo_http = _httpx.Client()
+        _photon_client = PhotonClient(
+            _config.settings.photon_url, _geo_http, _config.settings.photon_timeout_seconds
+        )
+        logger.info("Photon geocoder configured.")
 
     # ── Token DB refresh (#61) ──────────────────────────────────────────────
     # Use _config.settings (module-level reference) so that test reloads of the
@@ -169,6 +208,9 @@ async def lifespan(app: FastAPI):
         except asyncio.CancelledError:
             pass
 
+    if _geo_http is not None:
+        _geo_http.close()
+
 
 app = FastAPI(
     title="PostalCode2NUTS",
@@ -178,7 +220,7 @@ app = FastAPI(
     ),
     version=__version__,
     lifespan=lifespan,
-    docs_url="/docs" if settings.docs_enabled else None,
+    docs_url=settings.docs_url if settings.docs_enabled else None,
     redoc_url="/redoc" if settings.docs_enabled else None,
 )
 app.state.limiter = limiter
@@ -324,6 +366,52 @@ def get_pattern(
 
 
 @app.get(
+    "/resolve",
+    response_model=ResolveResponse,
+    responses={
+        400: {"model": ErrorResponse, "description": "Unsupported country"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+    },
+    summary="Resolve NUTS with a geocoding fallback for weak postal results",
+)
+@limiter.limit(settings.rate_limit, exempt_when=is_trusted_request)
+def resolve_endpoint(
+    request: Request,
+    response: Response,
+    country: str = Query(
+        ...,
+        min_length=2,
+        max_length=2,
+        pattern=r"^[A-Za-z]{2}$",
+        examples=["BE", "DE"],
+    ),
+    postal_code: str = Query(..., max_length=20, examples=["3080", "10115"]),
+    street: str | None = Query(default=None, max_length=200),
+    city: str | None = Query(default=None, max_length=120),
+):
+    cc = normalize_country(country)
+    if cc not in get_loaded_countries():
+        raise HTTPException(status_code=400, detail=f"Country '{cc}' is not supported.")
+    geocode_fn = _photon_client.geocode if _photon_client is not None else None
+    if _nuts_pip is None:
+        geocode_fn = None  # PIP unavailable → cannot resolve a coordinate
+    result = _resolve(
+        cc,
+        postal_code,
+        street,
+        city,
+        lookup_fn=lookup,
+        geocode_fn=geocode_fn,
+        pip=_nuts_pip,
+        name_fn=lambda code: get_nuts_names().get(code),
+        threshold=settings.resolve_confidence_threshold,
+    )
+    # /resolve carries PII → do not cache.
+    response.headers["Cache-Control"] = "no-store"
+    return ResolveResponse(**result)
+
+
+@app.get(
     "/",
     summary="Service entry point",
     include_in_schema=False,
@@ -374,6 +462,8 @@ def health(response: Response):
         last_updated=get_data_loaded_at(),
         token_db_stale=token_db_stale,
         estimates_refresh_stale=_get_estimates_refresh_stale(),
+        geocoder_configured=bool(_config.settings.photon_url),
+        pip_ready=_nuts_pip is not None,
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -120,19 +120,24 @@ async def lifespan(app: FastAPI):
         logger.warning("Serving STALE data — TERCET refresh failed, using expired cache")
 
     # ── NUTS polygons + geocoder for /resolve (#resolve-endpoint) ───────────
+    # PIP is only useful with a geocoder to produce coordinates, so the ~160 MB
+    # polygon load is skipped entirely in the Lite tier (no PC2NUTS_PHOTON_URL).
     global _nuts_pip, _photon_client, _geo_http
-    try:
-        with _httpx.Client() as _dl_client:
-            _nuts_pip = load_nuts_pip(
-                url=settings.nuts_geojson_url,
-                path=settings.nuts_geojson_path,
-                cache_dir=settings.data_dir,
-                client=_dl_client,
-            )
-        logger.info("NUTS polygons loaded — /resolve PIP ready.")
-    except Exception:
-        logger.exception("NUTS polygon load failed — /resolve will serve postal-only")
-        _nuts_pip = None
+    if settings.photon_url:
+        try:
+            with _httpx.Client() as _dl_client:
+                _nuts_pip = load_nuts_pip(
+                    url=settings.nuts_geojson_url,
+                    path=settings.nuts_geojson_path,
+                    cache_dir=settings.data_dir,
+                    client=_dl_client,
+                )
+            logger.info("NUTS polygons loaded — /resolve PIP ready.")
+        except Exception:
+            logger.exception("NUTS polygon load failed — /resolve will serve postal-only")
+            _nuts_pip = None
+    else:
+        logger.info("Lite tier: PC2NUTS_PHOTON_URL unset — geocoding + PIP disabled.")
     if _config.settings.photon_url:
         _geo_http = _httpx.Client()
         _photon_client = PhotonClient(

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,8 @@ from contextlib import asynccontextmanager
 from logging.handlers import RotatingFileHandler
 
 from fastapi import FastAPI, HTTPException, Query, Request, Response
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from slowapi.errors import RateLimitExceeded
@@ -120,12 +122,13 @@ async def lifespan(app: FastAPI):
     # ── NUTS polygons + geocoder for /resolve (#resolve-endpoint) ───────────
     global _nuts_pip, _photon_client, _geo_http
     try:
-        _nuts_pip = load_nuts_pip(
-            url=settings.nuts_geojson_url,
-            path=settings.nuts_geojson_path,
-            cache_dir=settings.data_dir,
-            client=_httpx.Client(),
-        )
+        with _httpx.Client() as _dl_client:
+            _nuts_pip = load_nuts_pip(
+                url=settings.nuts_geojson_url,
+                path=settings.nuts_geojson_path,
+                cache_dir=settings.data_dir,
+                client=_dl_client,
+            )
         logger.info("NUTS polygons loaded — /resolve PIP ready.")
     except Exception:
         logger.exception("NUTS polygon load failed — /resolve will serve postal-only")
@@ -248,6 +251,33 @@ def _rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONRespons
 
 
 app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
+
+
+def _validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Return 422 like FastAPI's default handler, but strip the raw `input`
+    from any error whose loc ends in `street`/`city` — /resolve accepts free-text
+    street/city and FastAPI's default handler would otherwise echo an
+    over-long value verbatim into the response body (PII leak)."""
+    redacted = False
+    errors = []
+    for err in exc.errors():
+        item = dict(err)
+        loc = item.get("loc", ())
+        if loc and loc[-1] in ("street", "city") and "input" in item:
+            item.pop("input", None)
+            redacted = True
+        errors.append(item)
+    headers = {"Cache-Control": "no-store"} if redacted else None
+    try:
+        return JSONResponse(status_code=422, content={"detail": errors}, headers=headers)
+    except TypeError:
+        # exc.errors() items may contain non-JSON-serializable values (e.g. a
+        # `ctx` dict holding a raw ValueError) — coerce to string as a fallback.
+        safe_errors = jsonable_encoder(errors, custom_encoder={Exception: str})
+        return JSONResponse(status_code=422, content={"detail": safe_errors}, headers=headers)
+
+
+app.add_exception_handler(RequestValidationError, _validation_error_handler)
 
 # CORS middleware
 if settings.cors_origins:
@@ -424,7 +454,7 @@ def root(request: Request, response: Response):
         "version": __version__,
         "links": {
             "openapi": f"{base}/openapi.json",
-            "docs": f"{base}/docs" if settings.docs_enabled else None,
+            "docs": f"{base}{settings.docs_url}" if settings.docs_enabled else None,
             "redoc": f"{base}/redoc" if settings.docs_enabled else None,
             "health": f"{base}/health",
             "lookup_example": f"{base}/lookup?country=DE&postal_code=10115",

--- a/app/models.py
+++ b/app/models.py
@@ -51,6 +51,7 @@ class HealthResponse(BaseModel):
 class GeocodeInfo(BaseModel):
     status: Literal[
         "ok",
+        "snapped",
         "no_result",
         "pip_outside",
         "no_address",
@@ -60,6 +61,9 @@ class GeocodeInfo(BaseModel):
     lat: float | None = None
     lon: float | None = None
     nuts3: str | None = None
+    snap_km: float | None = Field(
+        default=None, description="Distance (km) the point was snapped to the nearest NUTS-3 region"
+    )
 
 
 class ResolveResponse(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -44,6 +44,8 @@ class HealthResponse(BaseModel):
     )
     token_db_stale: bool | None = None
     estimates_refresh_stale: bool | None = None
+    geocoder_configured: bool = Field(default=False, description="True if PC2NUTS_PHOTON_URL is set")
+    pip_ready: bool = Field(default=False, description="True if NUTS polygons loaded for /resolve")
 
 
 class GeocodeInfo(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -44,3 +44,34 @@ class HealthResponse(BaseModel):
     )
     token_db_stale: bool | None = None
     estimates_refresh_stale: bool | None = None
+
+
+class GeocodeInfo(BaseModel):
+    status: Literal[
+        "ok",
+        "no_result",
+        "pip_outside",
+        "no_address",
+        "not_attempted",
+        "geocoder_unavailable",
+    ] = Field(description="What the geocode fallback did")
+    lat: float | None = None
+    lon: float | None = None
+    nuts3: str | None = None
+
+
+class ResolveResponse(BaseModel):
+    country_code: str
+    postal_code: str
+    resolved_via: Literal["postal", "geocode", "none"] = Field(
+        description="Which path produced the returned NUTS"
+    )
+    match_type: str | None = Field(description="Postal-path match type")
+    nuts1: str | None = None
+    nuts1_name: str | None = None
+    nuts2: str | None = None
+    nuts2_name: str | None = None
+    nuts3: str | None = None
+    nuts3_name: str | None = None
+    nuts3_confidence: float | None = None
+    geocode: GeocodeInfo

--- a/app/nuts_pip.py
+++ b/app/nuts_pip.py
@@ -8,12 +8,25 @@ levels 0-2 are prefixes of the matched level-3 id.
 from __future__ import annotations
 
 import json
+import math
 import zipfile
 from pathlib import Path
 
 from shapely import STRtree
-from shapely.geometry import Point, shape
+from shapely.geometry import Point, box, shape
 from shapely.geometry.base import BaseGeometry
+from shapely.ops import nearest_points
+
+_EARTH_KM = 6371.0088
+
+
+def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in km between two (lat, lon) points."""
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlmb = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
+    return 2 * _EARTH_KM * math.asin(math.sqrt(a))
 
 
 def load_nuts3_features(geojson_path: str | Path) -> list[tuple[str, BaseGeometry]]:
@@ -64,3 +77,42 @@ class NutsPip:
                 nid = self._ids[idx]
                 return {"nuts3": nid, "nuts2": nid[:4], "nuts1": nid[:3], "nuts0": nid[:2]}
         return None
+
+    def nearest(self, lat: float, lon: float, max_km: float, country: str | None = None) -> dict | None:
+        """Snap a point that fell outside every polygon to the nearest NUTS-3 region.
+
+        Used to rescue coastline/border points where a valid geocode lands just
+        outside a (generalized) NUTS polygon. Returns the same hierarchy dict as
+        ``lookup`` plus ``snap_km`` (the distance snapped), or None when nothing is
+        within ``max_km``. When ``country`` is given, only regions whose NUTS id
+        carries that country prefix are considered — this prevents snapping across a
+        border into the wrong country. ``max_km <= 0`` disables snapping.
+        """
+        if max_km <= 0:
+            return None
+        pt = Point(lon, lat)
+        # Coarse bbox prefilter sized in degrees for this latitude (lon compresses
+        # by cos(lat)); the exact distance is computed geodesically below.
+        dlat = max_km / 110.574
+        coslat = max(math.cos(math.radians(lat)), 0.01)
+        dlon = max_km / (111.320 * coslat)
+        search = box(lon - dlon, lat - dlat, lon + dlon, lat + dlat)
+
+        best_id: str | None = None
+        best_km = float("inf")
+        for idx in self._tree.query(search):
+            nid = self._ids[idx]
+            if country and not nid.startswith(country):
+                continue
+            on_geom, _ = nearest_points(self._geoms[idx], pt)
+            d = _haversine_km(lat, lon, on_geom.y, on_geom.x)
+            if d < best_km:
+                best_km, best_id = d, nid
+
+        if best_id is None or best_km > max_km:
+            return None
+        nid = best_id
+        return {
+            "nuts3": nid, "nuts2": nid[:4], "nuts1": nid[:3], "nuts0": nid[:2],
+            "snap_km": round(best_km, 3),
+        }

--- a/app/nuts_pip.py
+++ b/app/nuts_pip.py
@@ -1,0 +1,66 @@
+"""Point-in-polygon NUTS-3 oracle over GISCO NUTS-2024 polygons (production).
+
+Loads GISCO reference NUTS regions (EPSG:4326, level 3), builds an STRtree, and
+resolves a (lat, lon) to its NUTS 0/1/2/3 codes. NUTS codes are hierarchical, so
+levels 0-2 are prefixes of the matched level-3 id.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from shapely import STRtree
+from shapely.geometry import Point, shape
+from shapely.geometry.base import BaseGeometry
+
+
+def load_nuts3_features(geojson_path: str | Path) -> list[tuple[str, BaseGeometry]]:
+    """Parse a GISCO NUTS GeoJSON (or a .zip containing one) into (nuts_id, geom)
+    pairs for level-3 regions only, in EPSG:4326 (lon/lat)."""
+    path = Path(geojson_path)
+    if path.suffix == ".zip":
+        with zipfile.ZipFile(path) as zf:
+            name = next(
+                (
+                    n
+                    for n in zf.namelist()
+                    if "_RG_" in n and "4326" in n and "LEVL_3" in n and n.endswith(".geojson")
+                ),
+                None,
+            )
+            if name is None:
+                raise ValueError(f"no 4326 LEVL_3 region (_RG_) GeoJSON member in {path}")
+            with zf.open(name) as fh:
+                data = json.load(fh)
+    else:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+
+    features: list[tuple[str, BaseGeometry]] = []
+    for feat in data["features"]:
+        props = feat["properties"]
+        if props.get("LEVL_CODE") != 3:
+            continue
+        features.append((props["NUTS_ID"], shape(feat["geometry"])))
+    return features
+
+
+class NutsPip:
+    """In-memory NUTS-3 point-in-polygon index."""
+
+    def __init__(self, features: list[tuple[str, BaseGeometry]]):
+        self._ids = [nid for nid, _ in features]
+        self._geoms = [geom for _, geom in features]
+        self._tree = STRtree(self._geoms)
+
+    def lookup(self, lat: float, lon: float) -> dict | None:
+        """Return {'nuts0','nuts1','nuts2','nuts3'} for the point, or None if it
+        falls outside every NUTS-3 region."""
+        pt = Point(lon, lat)  # GeoJSON/shapely axis order is (x=lon, y=lat)
+        for idx in self._tree.query(pt):
+            if self._geoms[idx].covers(pt):
+                nid = self._ids[idx]
+                return {"nuts3": nid, "nuts2": nid[:4], "nuts1": nid[:3], "nuts0": nid[:2]}
+        return None

--- a/app/nuts_pip.py
+++ b/app/nuts_pip.py
@@ -113,6 +113,9 @@ class NutsPip:
             return None
         nid = best_id
         return {
-            "nuts3": nid, "nuts2": nid[:4], "nuts1": nid[:3], "nuts0": nid[:2],
+            "nuts3": nid,
+            "nuts2": nid[:4],
+            "nuts1": nid[:3],
+            "nuts0": nid[:2],
             "snap_km": round(best_km, 3),
         }

--- a/app/nuts_polygons.py
+++ b/app/nuts_polygons.py
@@ -1,0 +1,31 @@
+"""Acquire the GISCO NUTS polygon set and build a NutsPip oracle.
+
+Mirrors data_loader's runtime-download-and-cache pattern: an explicit local
+path wins (tests / pre-staged file); otherwise the zip is fetched once from the
+configured URL into the data-dir cache and reused on subsequent boots.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+from app.nuts_pip import NutsPip, load_nuts3_features
+
+_CACHE_NAME = "ref-nuts-polygons.geojson.zip"
+
+
+def load_nuts_pip(*, url: str, path: str, cache_dir: str, client: httpx.Client | None) -> NutsPip:
+    """Build a NutsPip from a local path if given, else a cached/downloaded zip."""
+    if path:
+        return NutsPip(load_nuts3_features(path))
+    cache = Path(cache_dir) / _CACHE_NAME
+    if not cache.exists():
+        if client is None:
+            raise ValueError("no cached polygons and no httpx client to download them")
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        resp = client.get(url, timeout=120, follow_redirects=True)
+        resp.raise_for_status()
+        cache.write_bytes(resp.content)
+    return NutsPip(load_nuts3_features(cache))

--- a/app/photon_client.py
+++ b/app/photon_client.py
@@ -4,6 +4,14 @@ Talks to a self-hosted Photon instance over the URL supplied by config
 (loopback in production, so address PII never leaves the host). Never raises:
 any transport/HTTP/parse failure yields None so the /resolve cascade can fall
 back to the postal result.
+
+Query strategy: Photon's free-text ``q`` returns NOTHING when a street and a
+postcode are combined in one string (e.g. "Museumpark 25, 3000 AE Rotterdam" →
+0 results) even though "Museumpark 25, Rotterdam" resolves fine. So we try a
+sequence of queries from most to least specific — street+city, then
+postcode+city, then city — and never put the street and the postcode together.
+The first query that returns a feature wins; the coarser fallbacks still land in
+the correct NUTS-3 region.
 """
 
 from __future__ import annotations
@@ -17,18 +25,30 @@ class PhotonClient:
         self._client = client
         self._timeout = timeout
 
-    def geocode(
-        self, street: str | None, city: str | None, postal_code: str | None
-    ) -> tuple[float, float] | None:
-        loc = f"{(postal_code or '').strip()} {(city or '').strip()}".strip()
-        parts = [p for p in ((street or "").strip(), loc) if p]
-        query = ", ".join(parts)
-        if not query:
-            return None
+    @staticmethod
+    def _candidates(street: str, city: str, postal_code: str) -> list[str]:
+        """Ordered, de-duplicated query candidates — never street+postcode together."""
+        out: list[str] = []
+        if street and city:
+            out.append(f"{street}, {city}")
+        if postal_code and city:
+            out.append(f"{postal_code} {city}")
+        if city:
+            out.append(city)
+        if street and postal_code and not city:
+            out.append(f"{street}, {postal_code}")
+        if postal_code:
+            out.append(postal_code)
+        if street and not city and not postal_code:
+            out.append(street)
+        seen: set[str] = set()
+        return [q for q in out if not (q in seen or seen.add(q))]
+
+    def _query(self, q: str) -> tuple[float, float] | None:
         try:
             resp = self._client.get(
                 f"{self._base}/api",
-                params={"q": query, "limit": 1},
+                params={"q": q, "limit": 1},
                 timeout=self._timeout,
             )
             resp.raise_for_status()
@@ -42,3 +62,15 @@ class PhotonClient:
         if len(coords) < 2:
             return None
         return (float(coords[1]), float(coords[0]))  # (lat, lon) from [lon, lat]
+
+    def geocode(
+        self, street: str | None, city: str | None, postal_code: str | None
+    ) -> tuple[float, float] | None:
+        candidates = self._candidates(
+            (street or "").strip(), (city or "").strip(), (postal_code or "").strip()
+        )
+        for q in candidates:
+            coord = self._query(q)
+            if coord is not None:
+                return coord
+        return None

--- a/app/photon_client.py
+++ b/app/photon_client.py
@@ -1,0 +1,44 @@
+"""Photon geocoding client — turns a free-form address into (lat, lon).
+
+Talks to a self-hosted Photon instance over the URL supplied by config
+(loopback in production, so address PII never leaves the host). Never raises:
+any transport/HTTP/parse failure yields None so the /resolve cascade can fall
+back to the postal result.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+class PhotonClient:
+    def __init__(self, base_url: str, client: httpx.Client, timeout: float = 5.0):
+        self._base = base_url.rstrip("/")
+        self._client = client
+        self._timeout = timeout
+
+    def geocode(
+        self, street: str | None, city: str | None, postal_code: str | None
+    ) -> tuple[float, float] | None:
+        loc = f"{(postal_code or '').strip()} {(city or '').strip()}".strip()
+        parts = [p for p in ((street or "").strip(), loc) if p]
+        query = ", ".join(parts)
+        if not query:
+            return None
+        try:
+            resp = self._client.get(
+                f"{self._base}/api",
+                params={"q": query, "limit": 1},
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except (httpx.HTTPError, ValueError):
+            return None
+        feats = data.get("features") or []
+        if not feats:
+            return None
+        coords = (feats[0].get("geometry") or {}).get("coordinates") or []
+        if len(coords) < 2:
+            return None
+        return (float(coords[1]), float(coords[0]))  # (lat, lon) from [lon, lat]

--- a/app/resolver.py
+++ b/app/resolver.py
@@ -68,6 +68,8 @@ def resolve(
 
     lat, lon = coord
     hit = pip.lookup(lat, lon)
+    if hit is not None and not hit["nuts3"].startswith(country):
+        hit = None  # cross-border geocode — Photon mislocated the address; treat as a PIP miss
     geocode: dict = {"status": "ok", "lat": lat, "lon": lon}
     if hit is None:
         # Point fell outside every polygon — try snapping to the nearest same-country

--- a/app/resolver.py
+++ b/app/resolver.py
@@ -1,0 +1,84 @@
+"""Pure postal→NUTS-or-geocode cascade for /resolve. HTTP-free, unit-testable.
+
+Geocoding fires ONLY when the postal result is weak (not_found or
+nuts3_confidence < threshold) AND the caller supplied a street/city address.
+Otherwise the postal result (even a weak one) is returned as best-effort — so a
+/resolve answer is never worse than /lookup.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+
+def resolve(
+    country: str,
+    postal_code: str,
+    street: str | None,
+    city: str | None,
+    *,
+    lookup_fn: Callable[[str, str], dict | None],
+    geocode_fn: Callable[[str | None, str | None, str], tuple[float, float] | None] | None,
+    pip,
+    name_fn: Callable[[str], str | None],
+    threshold: float = 0.85,
+) -> dict:
+    current = lookup_fn(country, postal_code)
+    match_type = current.get("match_type") if current else "not_found"
+    conf = current.get("nuts3_confidence") if current else None
+    weak = current is None or (conf is not None and conf < threshold)
+    has_address = bool((street or "").strip() or (city or "").strip())
+
+    def _postal() -> dict:
+        if current is None:
+            return {
+                "resolved_via": "none",
+                "nuts1": None,
+                "nuts1_name": None,
+                "nuts2": None,
+                "nuts2_name": None,
+                "nuts3": None,
+                "nuts3_name": None,
+                "nuts3_confidence": None,
+            }
+        return {
+            "resolved_via": "postal",
+            "nuts1": current.get("nuts1"),
+            "nuts1_name": current.get("nuts1_name"),
+            "nuts2": current.get("nuts2"),
+            "nuts2_name": current.get("nuts2_name"),
+            "nuts3": current.get("nuts3"),
+            "nuts3_name": current.get("nuts3_name"),
+            "nuts3_confidence": current.get("nuts3_confidence"),
+        }
+
+    base = {"country_code": country, "postal_code": postal_code, "match_type": match_type}
+
+    if not weak:
+        return {**base, **_postal(), "geocode": {"status": "not_attempted"}}
+    if not has_address:
+        return {**base, **_postal(), "geocode": {"status": "no_address"}}
+    if geocode_fn is None:
+        return {**base, **_postal(), "geocode": {"status": "geocoder_unavailable"}}
+
+    coord = geocode_fn(street, city, postal_code)
+    if coord is None:
+        return {**base, **_postal(), "geocode": {"status": "no_result"}}
+
+    lat, lon = coord
+    hit = pip.lookup(lat, lon)
+    if hit is None:
+        return {**base, **_postal(), "geocode": {"status": "pip_outside", "lat": lat, "lon": lon}}
+
+    return {
+        **base,
+        "resolved_via": "geocode",
+        "nuts1": hit["nuts1"],
+        "nuts1_name": name_fn(hit["nuts1"]),
+        "nuts2": hit["nuts2"],
+        "nuts2_name": name_fn(hit["nuts2"]),
+        "nuts3": hit["nuts3"],
+        "nuts3_name": name_fn(hit["nuts3"]),
+        "nuts3_confidence": None,
+        "geocode": {"status": "ok", "lat": lat, "lon": lon, "nuts3": hit["nuts3"]},
+    }

--- a/app/resolver.py
+++ b/app/resolver.py
@@ -22,6 +22,7 @@ def resolve(
     pip,
     name_fn: Callable[[str], str | None],
     threshold: float = 0.85,
+    snap_km: float = 0.0,
 ) -> dict:
     current = lookup_fn(country, postal_code)
     match_type = current.get("match_type") if current else "not_found"
@@ -67,9 +68,17 @@ def resolve(
 
     lat, lon = coord
     hit = pip.lookup(lat, lon)
+    geocode: dict = {"status": "ok", "lat": lat, "lon": lon}
     if hit is None:
-        return {**base, **_postal(), "geocode": {"status": "pip_outside", "lat": lat, "lon": lon}}
+        # Point fell outside every polygon — try snapping to the nearest same-country
+        # NUTS-3 region (coastline/border rescue) before giving up.
+        snapped = pip.nearest(lat, lon, snap_km, country) if snap_km and snap_km > 0 else None
+        if snapped is None:
+            return {**base, **_postal(), "geocode": {"status": "pip_outside", "lat": lat, "lon": lon}}
+        hit = snapped
+        geocode = {"status": "snapped", "lat": lat, "lon": lon, "snap_km": snapped["snap_km"]}
 
+    geocode["nuts3"] = hit["nuts3"]
     return {
         **base,
         "resolved_via": "geocode",
@@ -80,5 +89,5 @@ def resolve(
         "nuts3": hit["nuts3"],
         "nuts3_name": name_fn(hit["nuts3"]),
         "nuts3_confidence": None,
-        "geocode": {"status": "ok", "lat": lat, "lon": lon, "nuts3": hit["nuts3"]},
+        "geocode": geocode,
     }

--- a/compose.full.yaml
+++ b/compose.full.yaml
@@ -1,0 +1,39 @@
+# Full-tier override: enables the /resolve geocoding cascade on top of compose.yaml.
+#
+#   docker compose -f compose.yaml -f compose.full.yaml up -d
+#
+# The Full tier needs a komoot Photon geocoder reachable at PC2NUTS_PHOTON_URL.
+# Because a Photon index is large (a country-subset extract up to the ~89 GB
+# planet), most operators run Photon as a separate host service and point the app
+# at it — that is the default wiring below (host.docker.internal:2322). See the
+# "Full tier" section of the README for how to obtain an index and run Photon.
+#
+# On startup the app auto-downloads the GISCO NUTS-2024 polygons (~160 MB) into
+# /app/data and caches them; set PC2NUTS_NUTS_GEOJSON_PATH instead to use a
+# pre-seeded file in the mounted volume and avoid the download.
+
+services:
+  api:
+    environment:
+      PC2NUTS_PHOTON_URL: "http://host.docker.internal:2322"
+      # PC2NUTS_NUTS_GEOJSON_PATH: "/app/data/ref-nuts-2024-01m.geojson.zip"  # pre-seeded, optional
+      # PC2NUTS_RESOLVE_CONFIDENCE_THRESHOLD: "0.85"  # geocode only when postal is weaker than this
+      # PC2NUTS_PIP_SNAP_KM: "2.0"                     # snap coastline points to nearest same-country region
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ---------------------------------------------------------------------------
+  # OPTIONAL: run Photon inside compose instead of as a host service. You must
+  # supply the index data in the `photon-data` volume first (see README). Then
+  # set PC2NUTS_PHOTON_URL above to "http://photon:2322".
+  #
+  # photon:
+  #   image: <komoot-photon-image>   # pin a specific Photon distribution; see README
+  #   command: ["serve", "-listen-ip", "0.0.0.0", "-listen-port", "2322"]
+  #   volumes:
+  #     - photon-data:/photon/photon_data
+  #   restart: unless-stopped
+  # ---------------------------------------------------------------------------
+
+# volumes:
+#   photon-data:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ bandit>=1.9.4,<2
 pip-audit>=2.10.1,<3
 pytest>=9.1.1,<10
 pytest-asyncio>=1.4.0,<2
-shapely>=2.0,<3

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,6 +14,7 @@ httptools==0.8.0
 httpx==0.28.1
 idna==3.18
 limits==5.8.0
+numpy==2.5.0
 packaging==26.2
 pydantic==2.13.4
 pydantic-settings==2.14.2
@@ -21,10 +22,11 @@ pydantic_core==2.46.4
 python-dotenv==1.2.2
 PyYAML==6.0.3
 redis==7.4.1
+shapely==2.1.2
 slowapi==0.1.10
 starlette==1.3.1
 typing-inspection==0.4.2
-typing_extensions==4.15.0
+typing_extensions==4.16.0
 uvicorn==0.49.0
 uvloop==0.22.1
 watchfiles==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ pydantic>=2.13.4,<3
 pydantic-settings>=2.14.2,<3
 slowapi>=0.1.10,<1
 limits[redis]>=5.8.0
+# Point-in-polygon NUTS resolution for /resolve (pulls numpy transitively)
+shapely>=2.0,<3
 python-dotenv>=1.2.2,<2
 # Transitive (via httpx); pinned to clear CVE-2026-45409
 idna>=3.18,<4

--- a/scripts/enrich_via_api.py
+++ b/scripts/enrich_via_api.py
@@ -1,0 +1,273 @@
+"""Enrich the organisations CSV with NUTS via the deployed PostalCode2NUTS API.
+
+For a row range [start, end) of the input CSV, call the live API for each row:
+  * /lookup (every row)            -> NUTS3_POSTAL, POSTAL_MATCH_TYPE, POSTAL_CONFIDENCE
+  * /resolve (weak rows w/ address) -> NUTS3_GEOCODED, GEOCODE_STATUS  (address->Photon->PIP)
+and derive NUTS3_FINAL + a clear RESOLUTION_METHOD per row.
+
+"Weak" = postal match_type == not_found OR nuts3_confidence < 0.85.
+
+Auth: sends the operator Bearer token on every call (bypasses the 1/s anon limit).
+Resumable: if the output file already has rows, their OIDs are skipped.
+Offline analysis tool — NOT imported by the served app; output holds addresses (PII)
+so it belongs under local-data/ (gitignored).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import httpx
+
+OUT_FIELDS = [
+    "OID", "COUNTRY_CD", "CITY", "STREET_NAME_AND_NUMBER", "POSTAL_CODE",
+    "NUTS3_POSTAL", "POSTAL_MATCH_TYPE", "POSTAL_CONFIDENCE",
+    "NUTS3_GEOCODED", "GEOCODE_STATUS",
+    "NUTS3_FINAL", "RESOLUTION_METHOD",
+]
+
+WEAK_THRESHOLD = 0.85
+
+# Per-country postal validation regex cache (fetched from the API's /pattern endpoint).
+_PATTERN_CACHE: dict[str, str | None] = {}
+
+
+def loose_extract_postal(regex: str | None, raw: str) -> str:
+    """Pull a postal-code-shaped token out of a messy POSTAL_CODE field.
+
+    The API's per-country regexes are anchored (``^...$``) so they only *validate*
+    an already-clean code; a field that carries extra text — e.g.
+    ``"37067 Valeggio Sul Mincio VR"`` or ``"Lorentzstraat 212 1971 HX Ijmuiden"`` —
+    fails validation and the /lookup call returns 422. Here we drop the anchors and
+    (1) match at the *start* of the field (the code almost always leads it), then
+    (2) fall back to searching anywhere (codes that trail the street, NL-style).
+    Returns the matched token, or "" if nothing matches. /lookup then does its own
+    normalization on whatever token we hand back.
+    """
+    if not regex or not raw:
+        return ""
+    body = regex
+    if body.startswith("^"):
+        body = body[1:]
+    if body.endswith("$"):
+        body = body[:-1]
+    try:
+        pat = re.compile(body, re.IGNORECASE)
+    except re.error:
+        return ""
+    up = raw.strip().upper()
+    m = pat.match(up) or pat.search(up)
+    return m.group(0) if m else ""
+
+
+def accept_geocode(country: str, nuts3: str) -> bool:
+    """Guard against cross-border geocode errors.
+
+    A geocoded NUTS3 for a given country must carry that country's NUTS prefix.
+    Photon occasionally matches an ambiguous address to the wrong country (observed:
+    an Albanian street resolving to DEG01/Stuttgart, a Serbian one to PL217/Poland);
+    such results are discarded rather than trusted, since a NUTS3 code always begins
+    with its country's two-letter code.
+    """
+    return bool(nuts3) and bool(country) and nuts3.upper().startswith(country.upper())
+
+
+def _country_regex(
+    client: httpx.Client, base: str, headers: dict, timeout: float, country: str
+) -> str | None:
+    """Fetch (and cache) a country's postal validation regex from the /pattern endpoint."""
+    if country in _PATTERN_CACHE:
+        return _PATTERN_CACHE[country]
+    rx: str | None = None
+    try:
+        st, body = _get(client, f"{base}/pattern", {"country": country}, headers, timeout)
+        if st == 200 and body:
+            rx = body.get("regex")
+    except RuntimeError:
+        rx = None
+    _PATTERN_CACHE[country] = rx
+    return rx
+
+
+def _get(client: httpx.Client, url: str, params: dict, headers: dict, timeout: float):
+    """GET with a few retries on transport errors; returns (status_code, json|None)."""
+    last_exc = None
+    for attempt in range(4):
+        try:
+            r = client.get(url, params=params, headers=headers, timeout=timeout)
+            if r.status_code >= 500:
+                last_exc = f"HTTP {r.status_code}"
+                time.sleep(0.5 * (attempt + 1))
+                continue
+            try:
+                return r.status_code, r.json()
+            except ValueError:
+                return r.status_code, None
+        except httpx.HTTPError as exc:
+            last_exc = str(exc)
+            time.sleep(0.5 * (attempt + 1))
+    raise RuntimeError(f"request failed after retries: {last_exc}")
+
+
+def process_row(row: dict, client: httpx.Client, base: str, headers: dict, timeout: float) -> dict:
+    country = (row.get("COUNTRY_CD") or "").strip()
+    pc = (row.get("POSTAL_CODE") or "").strip()
+    street = (row.get("STREET_NAME_AND_NUMBER") or "").strip()
+    city = (row.get("CITY") or "").strip()
+
+    out = {k: (row.get(k) or "") for k in
+           ("OID", "COUNTRY_CD", "CITY", "STREET_NAME_AND_NUMBER", "POSTAL_CODE")}
+    nuts3_postal = match_type = conf = ""
+    nuts3_geocoded = geocode_status = ""
+
+    # --- postal path (with one sanitization retry on a 422) ---
+    st, body = _get(client, f"{base}/lookup", {"country": country, "postal_code": pc}, headers, timeout)
+    if st == 422 and pc:
+        # /lookup rejected the raw code — it likely carries extra text (city, street).
+        # Pull out the code-shaped token and retry once with it.
+        cand = loose_extract_postal(_country_regex(client, base, headers, timeout, country), pc)
+        if cand and cand != pc:
+            st2, body2 = _get(client, f"{base}/lookup",
+                              {"country": country, "postal_code": cand}, headers, timeout)
+            if st2 != 422:  # accept the sanitized retry only once it clears validation
+                st, body, pc = st2, body2, cand
+    if st == 200 and body:
+        nuts3_postal = body.get("nuts3") or ""
+        match_type = body.get("match_type") or ""
+        c = body.get("nuts3_confidence")
+        conf = "" if c is None else f"{c:.2f}"
+    elif st == 404:
+        match_type = "not_found"
+    elif st == 400:
+        match_type = "unsupported"
+    else:
+        match_type = f"error_{st}"
+
+    # --- decide routing ---
+    # "weak" now also covers residual postal errors (a malformed/rejected code) so a
+    # row with a real street/city still gets a geocode attempt instead of being dropped.
+    weak = (match_type == "not_found" or match_type.startswith("error_")
+            or (conf != "" and float(conf) < WEAK_THRESHOLD))
+    has_address = bool(street or city)
+    routable = match_type != "unsupported"
+
+    if weak and has_address and routable:
+        st2, body2 = _get(
+            client, f"{base}/resolve",
+            {"country": country, "postal_code": pc, "street": street, "city": city},
+            headers, timeout,
+        )
+        if st2 == 200 and body2:
+            g = body2.get("geocode") or {}
+            geocode_status = g.get("status") or ""
+            if geocode_status == "ok":
+                cand = g.get("nuts3") or ""
+                if accept_geocode(country, cand):
+                    nuts3_geocoded = cand
+                else:
+                    geocode_status = "wrong_country"  # cross-border miss — discard
+        else:
+            geocode_status = f"error_{st2}"
+    elif weak and not has_address and routable:
+        geocode_status = "no_address"
+    elif not routable:
+        geocode_status = "unsupported"
+    else:
+        geocode_status = "not_attempted"
+
+    # --- derive final + method ---
+    if nuts3_geocoded:
+        nuts3_final, method = nuts3_geocoded, "geocoded"
+    elif nuts3_postal:
+        nuts3_final, method = nuts3_postal, f"postal:{match_type}"
+    elif match_type == "unsupported":
+        nuts3_final, method = "", "unsupported"
+    else:
+        nuts3_final, method = "", "unresolved"
+
+    out.update({
+        "NUTS3_POSTAL": nuts3_postal, "POSTAL_MATCH_TYPE": match_type, "POSTAL_CONFIDENCE": conf,
+        "NUTS3_GEOCODED": nuts3_geocoded, "GEOCODE_STATUS": geocode_status,
+        "NUTS3_FINAL": nuts3_final, "RESOLUTION_METHOD": method,
+    })
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--base-url", required=True)
+    ap.add_argument("--token", required=True)
+    ap.add_argument("--start", type=int, default=0)
+    ap.add_argument("--end", type=int, default=None)
+    ap.add_argument("--concurrency", type=int, default=5)
+    ap.add_argument("--timeout", type=float, default=15.0)
+    args = ap.parse_args()
+
+    base = args.base_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {args.token}"}
+
+    with open(args.input, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    end = args.end if args.end is not None else len(rows)
+    chunk = rows[args.start:end]
+
+    # resume: skip OIDs already present in the output
+    done: set[str] = set()
+    try:
+        with open(args.output, newline="", encoding="utf-8") as f:
+            done = {r["OID"] for r in csv.DictReader(f)}
+    except FileNotFoundError:
+        pass
+    todo = [r for r in chunk if (r.get("OID") or "") not in done]
+    print(f"range [{args.start}:{end}) = {len(chunk)} rows; {len(done)} already done; {len(todo)} to do",
+          file=sys.stderr, flush=True)
+
+    write_lock = threading.Lock()
+    counts: dict[str, int] = {}
+    processed = 0
+    t0 = time.monotonic()
+
+    new_file = not done
+    with open(args.output, "a", newline="", encoding="utf-8") as fout:
+        writer = csv.DictWriter(fout, fieldnames=OUT_FIELDS)
+        if new_file:
+            writer.writeheader()
+            fout.flush()
+
+        client = httpx.Client(
+            limits=httpx.Limits(max_connections=args.concurrency + 2, max_keepalive_connections=args.concurrency + 2)
+        )
+
+        def work(row):
+            return process_row(row, client, base, headers, args.timeout)
+
+        with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
+            for rec in ex.map(work, todo):
+                with write_lock:
+                    writer.writerow(rec)
+                    counts[rec["RESOLUTION_METHOD"]] = counts.get(rec["RESOLUTION_METHOD"], 0) + 1
+                    processed += 1
+                    if processed % 500 == 0:
+                        fout.flush()
+                        rate = processed / (time.monotonic() - t0)
+                        print(f"  {processed}/{len(todo)} ({rate:.0f}/s)", file=sys.stderr, flush=True)
+        client.close()
+
+    elapsed = time.monotonic() - t0
+    print(f"DONE {processed} rows in {elapsed:.1f}s ({processed/max(elapsed,0.001):.0f}/s)", file=sys.stderr)
+    print("method distribution:", file=sys.stderr)
+    for m, n in sorted(counts.items(), key=lambda kv: -kv[1]):
+        print(f"  {m}: {n}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/enrich_via_api.py
+++ b/scripts/enrich_via_api.py
@@ -66,6 +66,9 @@ def loose_extract_postal(regex: str | None, raw: str) -> str:
     return m.group(0) if m else ""
 
 
+_ISO_TO_NUTS = {"GR": "EL", "GB": "UK"}
+
+
 def accept_geocode(country: str, nuts3: str) -> bool:
     """Guard against cross-border geocode errors.
 
@@ -75,7 +78,10 @@ def accept_geocode(country: str, nuts3: str) -> bool:
     such results are discarded rather than trusted, since a NUTS3 code always begins
     with its country's two-letter code.
     """
-    return bool(nuts3) and bool(country) and nuts3.upper().startswith(country.upper())
+    if not (country and nuts3):
+        return False
+    cc = _ISO_TO_NUTS.get(country.upper(), country.upper())
+    return nuts3.upper().startswith(cc)
 
 
 def _country_regex(

--- a/scripts/enrich_via_api.py
+++ b/scripts/enrich_via_api.py
@@ -26,10 +26,18 @@ from concurrent.futures import ThreadPoolExecutor
 import httpx
 
 OUT_FIELDS = [
-    "OID", "COUNTRY_CD", "CITY", "STREET_NAME_AND_NUMBER", "POSTAL_CODE",
-    "NUTS3_POSTAL", "POSTAL_MATCH_TYPE", "POSTAL_CONFIDENCE",
-    "NUTS3_GEOCODED", "GEOCODE_STATUS",
-    "NUTS3_FINAL", "RESOLUTION_METHOD",
+    "OID",
+    "COUNTRY_CD",
+    "CITY",
+    "STREET_NAME_AND_NUMBER",
+    "POSTAL_CODE",
+    "NUTS3_POSTAL",
+    "POSTAL_MATCH_TYPE",
+    "POSTAL_CONFIDENCE",
+    "NUTS3_GEOCODED",
+    "GEOCODE_STATUS",
+    "NUTS3_FINAL",
+    "RESOLUTION_METHOD",
 ]
 
 WEAK_THRESHOLD = 0.85
@@ -127,8 +135,9 @@ def process_row(row: dict, client: httpx.Client, base: str, headers: dict, timeo
     street = (row.get("STREET_NAME_AND_NUMBER") or "").strip()
     city = (row.get("CITY") or "").strip()
 
-    out = {k: (row.get(k) or "") for k in
-           ("OID", "COUNTRY_CD", "CITY", "STREET_NAME_AND_NUMBER", "POSTAL_CODE")}
+    out = {
+        k: (row.get(k) or "") for k in ("OID", "COUNTRY_CD", "CITY", "STREET_NAME_AND_NUMBER", "POSTAL_CODE")
+    }
     nuts3_postal = match_type = conf = ""
     nuts3_geocoded = geocode_status = ""
 
@@ -139,8 +148,9 @@ def process_row(row: dict, client: httpx.Client, base: str, headers: dict, timeo
         # Pull out the code-shaped token and retry once with it.
         cand = loose_extract_postal(_country_regex(client, base, headers, timeout, country), pc)
         if cand and cand != pc:
-            st2, body2 = _get(client, f"{base}/lookup",
-                              {"country": country, "postal_code": cand}, headers, timeout)
+            st2, body2 = _get(
+                client, f"{base}/lookup", {"country": country, "postal_code": cand}, headers, timeout
+            )
             if st2 != 422:  # accept the sanitized retry only once it clears validation
                 st, body, pc = st2, body2, cand
     if st == 200 and body:
@@ -158,16 +168,21 @@ def process_row(row: dict, client: httpx.Client, base: str, headers: dict, timeo
     # --- decide routing ---
     # "weak" now also covers residual postal errors (a malformed/rejected code) so a
     # row with a real street/city still gets a geocode attempt instead of being dropped.
-    weak = (match_type == "not_found" or match_type.startswith("error_")
-            or (conf != "" and float(conf) < WEAK_THRESHOLD))
+    weak = (
+        match_type == "not_found"
+        or match_type.startswith("error_")
+        or (conf != "" and float(conf) < WEAK_THRESHOLD)
+    )
     has_address = bool(street or city)
     routable = match_type != "unsupported"
 
     if weak and has_address and routable:
         st2, body2 = _get(
-            client, f"{base}/resolve",
+            client,
+            f"{base}/resolve",
             {"country": country, "postal_code": pc, "street": street, "city": city},
-            headers, timeout,
+            headers,
+            timeout,
         )
         if st2 == 200 and body2:
             g = body2.get("geocode") or {}
@@ -197,11 +212,17 @@ def process_row(row: dict, client: httpx.Client, base: str, headers: dict, timeo
     else:
         nuts3_final, method = "", "unresolved"
 
-    out.update({
-        "NUTS3_POSTAL": nuts3_postal, "POSTAL_MATCH_TYPE": match_type, "POSTAL_CONFIDENCE": conf,
-        "NUTS3_GEOCODED": nuts3_geocoded, "GEOCODE_STATUS": geocode_status,
-        "NUTS3_FINAL": nuts3_final, "RESOLUTION_METHOD": method,
-    })
+    out.update(
+        {
+            "NUTS3_POSTAL": nuts3_postal,
+            "POSTAL_MATCH_TYPE": match_type,
+            "POSTAL_CONFIDENCE": conf,
+            "NUTS3_GEOCODED": nuts3_geocoded,
+            "GEOCODE_STATUS": geocode_status,
+            "NUTS3_FINAL": nuts3_final,
+            "RESOLUTION_METHOD": method,
+        }
+    )
     return out
 
 
@@ -223,7 +244,7 @@ def main() -> int:
     with open(args.input, newline="", encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
     end = args.end if args.end is not None else len(rows)
-    chunk = rows[args.start:end]
+    chunk = rows[args.start : end]
 
     # resume: skip OIDs already present in the output
     done: set[str] = set()
@@ -233,8 +254,11 @@ def main() -> int:
     except FileNotFoundError:
         pass
     todo = [r for r in chunk if (r.get("OID") or "") not in done]
-    print(f"range [{args.start}:{end}) = {len(chunk)} rows; {len(done)} already done; {len(todo)} to do",
-          file=sys.stderr, flush=True)
+    print(
+        f"range [{args.start}:{end}) = {len(chunk)} rows; {len(done)} already done; {len(todo)} to do",
+        file=sys.stderr,
+        flush=True,
+    )
 
     write_lock = threading.Lock()
     counts: dict[str, int] = {}
@@ -249,7 +273,10 @@ def main() -> int:
             fout.flush()
 
         client = httpx.Client(
-            limits=httpx.Limits(max_connections=args.concurrency + 2, max_keepalive_connections=args.concurrency + 2)
+            limits=httpx.Limits(
+                max_connections=args.concurrency + 2,
+                max_keepalive_connections=args.concurrency + 2,
+            )
         )
 
         def work(row):
@@ -268,7 +295,9 @@ def main() -> int:
         client.close()
 
     elapsed = time.monotonic() - t0
-    print(f"DONE {processed} rows in {elapsed:.1f}s ({processed/max(elapsed,0.001):.0f}/s)", file=sys.stderr)
+    print(
+        f"DONE {processed} rows in {elapsed:.1f}s ({processed / max(elapsed, 0.001):.0f}/s)", file=sys.stderr
+    )
     print("method distribution:", file=sys.stderr)
     for m, n in sorted(counts.items(), key=lambda kv: -kv[1]):
         print(f"  {m}: {n}", file=sys.stderr)

--- a/scripts/enrich_via_api.py
+++ b/scripts/enrich_via_api.py
@@ -166,7 +166,7 @@ def process_row(row: dict, client: httpx.Client, base: str, headers: dict, timeo
         if st2 == 200 and body2:
             g = body2.get("geocode") or {}
             geocode_status = g.get("status") or ""
-            if geocode_status == "ok":
+            if geocode_status in ("ok", "snapped"):  # snapped = nearest-polygon rescue
                 cand = g.get("nuts3") or ""
                 if accept_geocode(country, cand):
                     nuts3_geocoded = cand

--- a/tests/test_enrich_via_api.py
+++ b/tests/test_enrich_via_api.py
@@ -61,6 +61,7 @@ class TestAcceptGeocode:
     def test_same_country_accepted(self):
         assert enrich.accept_geocode("AL", "AL022") is True
         assert enrich.accept_geocode("el", "EL642") is True  # case-insensitive
+        assert enrich.accept_geocode("GR", "EL642") is True  # ISO GR remaps to NUTS EL
 
     def test_cross_border_rejected(self):
         # the failure modes observed in the estimated-rows sample

--- a/tests/test_enrich_via_api.py
+++ b/tests/test_enrich_via_api.py
@@ -1,0 +1,72 @@
+"""Tests for scripts/enrich_via_api.py sanitization + geocode guard helpers.
+
+Covers the two P4 follow-up fixes:
+  * loose_extract_postal — pull a valid code out of a messy POSTAL_CODE field so a
+    /lookup 422 (malformed input) can be retried instead of dropped to unresolved.
+  * accept_geocode — reject cross-border geocode results (wrong-country NUTS3).
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "enrich_via_api", REPO / "scripts" / "enrich_via_api.py"
+)
+enrich = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(enrich)
+
+# Real anchored regexes from app/postal_patterns.json for the countries that
+# dominated the error_422 tail (ES, PT, IT, HU, FI, NL, HR).
+IT = r"^(?:I[\s\-–—.]*|IT[\s\-–—.]*)?([0-9]{5})$"
+PT = r"^(?:P[\s\-–—.]*|PT[\s\-–—.]*)?([0-9]{4})[\s\-]?([0-9]{3})$"
+HU = r"^(?:H[\s\-–—.]*|HU[\s\-–—.]*)?([0-9]{4})$"
+FI = r"^(?:FI(?:N)?[\s\-–—.]*)?([0-9]{5})$"
+NL = r"^(?:NL[\s\-–—.]*)?(\d{4}\s?[A-Z]{2})$"
+HR = r"^(?:HR[\s\-–—.]*)?([0-9]{5})$"
+
+
+class TestLooseExtractPostal:
+    def test_code_leads_the_field(self):
+        # code at the start, trailing text (the common case)
+        assert enrich.loose_extract_postal(IT, "37067 Valeggio Sul Mincio VR") == "37067"
+        assert enrich.loose_extract_postal(HU, "1083 Budapest, Szigetvári utca 1.") == "1083"
+        assert enrich.loose_extract_postal(FI, "00099 Helsingin kaupunki") == "00099"
+        assert enrich.loose_extract_postal(HR, "42223 Varaždinske Toplice") == "42223"
+
+    def test_hyphenated_pt_code(self):
+        assert enrich.loose_extract_postal(PT, "4575-297 Paredes, PNF") == "4575-297"
+
+    def test_alnum_code_trailing_in_field(self):
+        # NL codes can trail the street; start-anchored fails, search succeeds
+        assert enrich.loose_extract_postal(NL, "Lorentzstraat 212 1971 HX Ijmuiden") == "1971 HX"
+
+    def test_already_clean_code_is_unchanged(self):
+        assert enrich.loose_extract_postal(IT, "37067") == "37067"
+
+    def test_no_code_present_returns_empty(self):
+        # junk / test rows have no code-shaped token
+        assert enrich.loose_extract_postal(IT, "mirceaTest8.03") == ""
+        assert enrich.loose_extract_postal(IT, "aaaaaaaaa") == ""
+
+    def test_missing_regex_or_input_returns_empty(self):
+        assert enrich.loose_extract_postal(None, "37067 Something") == ""
+        assert enrich.loose_extract_postal(IT, "") == ""
+
+    def test_bad_regex_does_not_raise(self):
+        assert enrich.loose_extract_postal("^([0-9]{5}$", "37067") == ""
+
+
+class TestAcceptGeocode:
+    def test_same_country_accepted(self):
+        assert enrich.accept_geocode("AL", "AL022") is True
+        assert enrich.accept_geocode("el", "EL642") is True  # case-insensitive
+
+    def test_cross_border_rejected(self):
+        # the failure modes observed in the estimated-rows sample
+        assert enrich.accept_geocode("AL", "DEG01") is False
+        assert enrich.accept_geocode("RS", "PL217") is False
+
+    def test_empty_inputs_rejected(self):
+        assert enrich.accept_geocode("AL", "") is False
+        assert enrich.accept_geocode("", "AL022") is False

--- a/tests/test_nuts_pip_app.py
+++ b/tests/test_nuts_pip_app.py
@@ -1,0 +1,51 @@
+"""Tests for app/nuts_pip.py (production point-in-polygon NUTS oracle)."""
+
+import json
+
+from shapely.geometry import box
+
+from app.nuts_pip import NutsPip, load_nuts3_features
+
+FEATURES = [
+    ("AB100", box(0.0, 0.0, 1.0, 1.0)),  # lon 0..1, lat 0..1
+    ("AB200", box(1.0, 0.0, 2.0, 1.0)),  # lon 1..2, lat 0..1
+]
+
+
+def test_point_inside_returns_hierarchy():
+    oracle = NutsPip(FEATURES)
+    assert oracle.lookup(0.5, 0.5) == {
+        "nuts3": "AB100",
+        "nuts2": "AB10",
+        "nuts1": "AB1",
+        "nuts0": "AB",
+    }
+
+
+def test_point_in_other_region():
+    assert NutsPip(FEATURES).lookup(0.5, 1.5)["nuts3"] == "AB200"
+
+
+def test_point_outside_returns_none():
+    assert NutsPip(FEATURES).lookup(50.0, 50.0) is None
+
+
+def test_load_filters_to_level_3(tmp_path):
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"NUTS_ID": "AB", "LEVL_CODE": 0},
+                "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [2, 0], [2, 1], [0, 1], [0, 0]]]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"NUTS_ID": "AB100", "LEVL_CODE": 3},
+                "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+            },
+        ],
+    }
+    p = tmp_path / "nuts.geojson"
+    p.write_text(json.dumps(geojson))
+    assert [nid for nid, _ in load_nuts3_features(p)] == ["AB100"]

--- a/tests/test_nuts_pip_app.py
+++ b/tests/test_nuts_pip_app.py
@@ -30,6 +30,44 @@ def test_point_outside_returns_none():
     assert NutsPip(FEATURES).lookup(50.0, 50.0) is None
 
 
+# AB100 (lon 0..1) and a foreign FR100 (lon -1..-0.02); a gap in between.
+SNAP_FEATURES = [
+    ("AB100", box(0.0, 0.0, 1.0, 1.0)),
+    ("FR100", box(-1.0, 0.0, -0.02, 1.0)),
+]
+
+
+def test_nearest_snaps_point_just_outside():
+    oracle = NutsPip(SNAP_FEATURES)
+    # (lat=0.5, lon=-0.015) is in the gap, ~0.55 km from FR100, ~1.67 km from AB100
+    hit = oracle.nearest(0.5, -0.015, max_km=3.0)
+    assert hit["nuts3"] == "FR100"  # nearest overall
+    assert 0.4 < hit["snap_km"] < 0.7
+
+
+def test_nearest_respects_country_filter():
+    oracle = NutsPip(SNAP_FEATURES)
+    # nearest is FR100, but restricting to country AB must pick the farther AB100
+    hit = oracle.nearest(0.5, -0.015, max_km=3.0, country="AB")
+    assert hit["nuts3"] == "AB100"
+    assert hit["nuts2"] == "AB10" and hit["nuts0"] == "AB"
+
+
+def test_nearest_returns_none_beyond_cap():
+    oracle = NutsPip(SNAP_FEATURES)
+    assert oracle.nearest(0.5, -0.015, max_km=1.0, country="AB") is None  # AB100 ~1.67 km
+
+
+def test_nearest_disabled_when_cap_zero():
+    oracle = NutsPip(SNAP_FEATURES)
+    assert oracle.nearest(0.5, -0.015, max_km=0.0) is None
+
+
+def test_nearest_none_when_no_same_country_region():
+    oracle = NutsPip(SNAP_FEATURES)
+    assert oracle.nearest(0.5, -0.015, max_km=3.0, country="ZZ") is None
+
+
 def test_load_filters_to_level_3(tmp_path):
     geojson = {
         "type": "FeatureCollection",

--- a/tests/test_nuts_polygons.py
+++ b/tests/test_nuts_polygons.py
@@ -1,0 +1,47 @@
+"""Tests for app/nuts_polygons.py."""
+
+import json
+
+import httpx
+
+from app.nuts_polygons import load_nuts_pip
+
+_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"NUTS_ID": "AB100", "LEVL_CODE": 3},
+            "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+        }
+    ],
+}
+
+
+def test_load_from_local_path(tmp_path):
+    p = tmp_path / "n.geojson"
+    p.write_text(json.dumps(_GEOJSON))
+    pip = load_nuts_pip(url="http://x", path=str(p), cache_dir=str(tmp_path), client=None)
+    assert pip.lookup(0.5, 0.5)["nuts3"] == "AB100"
+
+
+def test_downloads_and_caches(tmp_path):
+    calls = {"n": 0}
+
+    def handler(req):
+        calls["n"] += 1
+        # a minimal zip containing the _RG_ member
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("NUTS_RG_01M_2024_4326_LEVL_3.geojson", json.dumps(_GEOJSON))
+        return httpx.Response(200, content=buf.getvalue())
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    pip = load_nuts_pip(url="http://x/n.zip", path="", cache_dir=str(tmp_path), client=client)
+    assert pip.lookup(0.5, 0.5)["nuts3"] == "AB100"
+    # second call uses the cache, no new download
+    load_nuts_pip(url="http://x/n.zip", path="", cache_dir=str(tmp_path), client=client)
+    assert calls["n"] == 1

--- a/tests/test_photon_client.py
+++ b/tests/test_photon_client.py
@@ -9,18 +9,60 @@ def _client(handler):
     return httpx.Client(transport=httpx.MockTransport(handler))
 
 
-def test_geocode_returns_lat_lon():
+def test_primary_query_is_street_city_not_postcode():
+    # The first query must be street+city — NOT street+postcode+city (which Photon
+    # returns 0 results for). Postcode is never combined with the street.
+    calls = []
+
     def handler(req):
-        assert req.url.params["q"] == "Markt, 3080 Tervuren"
+        calls.append(req.url.params["q"])
         return httpx.Response(
             200, json={"features": [{"geometry": {"type": "Point", "coordinates": [4.5149, 50.8246]}}]}
         )
 
     pc = PhotonClient("http://photon", _client(handler))
     assert pc.geocode("Markt", "Tervuren", "3080") == (50.8246, 4.5149)
+    assert calls[0] == "Markt, Tervuren"  # street+city first, no postcode
 
 
-def test_empty_features_returns_none():
+def test_falls_back_to_postcode_city_when_street_query_empty():
+    def handler(req):
+        q = req.url.params["q"]
+        if q == "Museumpark 25, Rotterdam":  # street+city → empty (the real-world failure)
+            return httpx.Response(200, json={"features": []})
+        if q == "3000 AE Rotterdam":  # postcode+city fallback → hit
+            return httpx.Response(200, json={"features": [{"geometry": {"coordinates": [4.47, 51.92]}}]})
+        return httpx.Response(200, json={"features": []})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    assert pc.geocode("Museumpark 25", "Rotterdam", "3000 AE") == (51.92, 4.47)
+
+
+def test_falls_back_to_city_when_street_and_postcode_empty():
+    def handler(req):
+        q = req.url.params["q"]
+        if q == "Rotterdam":
+            return httpx.Response(200, json={"features": [{"geometry": {"coordinates": [4.48, 51.92]}}]})
+        return httpx.Response(200, json={"features": []})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    assert pc.geocode("Nowhere St 9", "Rotterdam", "0000 ZZ") == (51.92, 4.48)
+
+
+def test_never_combines_street_and_postcode():
+    seen = []
+
+    def handler(req):
+        seen.append(req.url.params["q"])
+        return httpx.Response(200, json={"features": []})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    pc.geocode("Museumpark 25", "Rotterdam", "3000 AE")
+    assert seen, "expected at least one query"
+    assert all(not ("Museumpark 25" in q and "3000 AE" in q) for q in seen)
+
+
+def test_all_queries_empty_returns_none():
     pc = PhotonClient("http://photon", _client(lambda r: httpx.Response(200, json={"features": []})))
     assert pc.geocode("X", "Y", "0000") is None
 

--- a/tests/test_photon_client.py
+++ b/tests/test_photon_client.py
@@ -1,0 +1,43 @@
+"""Tests for app/photon_client.py."""
+
+import httpx
+
+from app.photon_client import PhotonClient
+
+
+def _client(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_geocode_returns_lat_lon():
+    def handler(req):
+        assert req.url.params["q"] == "Markt, 3080 Tervuren"
+        return httpx.Response(
+            200, json={"features": [{"geometry": {"type": "Point", "coordinates": [4.5149, 50.8246]}}]}
+        )
+
+    pc = PhotonClient("http://photon", _client(handler))
+    assert pc.geocode("Markt", "Tervuren", "3080") == (50.8246, 4.5149)
+
+
+def test_empty_features_returns_none():
+    pc = PhotonClient("http://photon", _client(lambda r: httpx.Response(200, json={"features": []})))
+    assert pc.geocode("X", "Y", "0000") is None
+
+
+def test_http_error_returns_none():
+    pc = PhotonClient("http://photon", _client(lambda r: httpx.Response(500)))
+    assert pc.geocode("X", "Y", "0000") is None
+
+
+def test_transport_error_returns_none():
+    def boom(req):
+        raise httpx.ConnectError("down", request=req)
+
+    pc = PhotonClient("http://photon", _client(boom))
+    assert pc.geocode("X", "Y", "0000") is None
+
+
+def test_blank_query_returns_none():
+    pc = PhotonClient("http://photon", _client(lambda r: httpx.Response(200, json={"features": []})))
+    assert pc.geocode(None, None, None) is None

--- a/tests/test_resolve_endpoint.py
+++ b/tests/test_resolve_endpoint.py
@@ -18,7 +18,7 @@ def client(tmp_path, monkeypatch):
         "features": [
             {
                 "type": "Feature",
-                "properties": {"NUTS_ID": "DE111", "LEVL_CODE": 3},
+                "properties": {"NUTS_ID": "BE241", "LEVL_CODE": 3},
                 "geometry": {
                     "type": "Polygon",
                     "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
@@ -75,7 +75,7 @@ def test_resolve_weak_geocodes(client):
     assert r.status_code == 200
     body = r.json()
     assert body["resolved_via"] == "geocode"
-    assert body["nuts3"] == "DE111"
+    assert body["nuts3"] == "BE241"
     assert body["geocode"]["status"] == "ok"
 
 

--- a/tests/test_resolve_endpoint.py
+++ b/tests/test_resolve_endpoint.py
@@ -1,0 +1,94 @@
+"""Integration tests for GET /resolve via TestClient."""
+
+import importlib
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from shapely.geometry import box  # noqa: F401  (ensures shapely present)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    # A tiny local polygon file so the oracle covers a known square.
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"NUTS_ID": "DE111", "LEVL_CODE": 3},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
+                },
+            }
+        ],
+    }
+    p = tmp_path / "nuts.geojson"
+    p.write_text(json.dumps(geojson))
+    monkeypatch.setenv("PC2NUTS_NUTS_GEOJSON_PATH", str(p))
+    monkeypatch.setenv("PC2NUTS_PHOTON_URL", "http://photon")
+    monkeypatch.setenv("PC2NUTS_TOKEN_DB_URL", "")
+    monkeypatch.setenv("PC2NUTS_ESTIMATES_REFRESH_URL", "")
+
+    import app.config as cfg
+
+    importlib.reload(cfg)
+    import app.main as main
+
+    importlib.reload(main)
+
+    # Force a weak postal result + a geocode that lands at (5,5) inside DE111.
+    monkeypatch.setattr(
+        main,
+        "lookup",
+        lambda c, p: {
+            "match_type": "approximate",
+            "nuts1": "BE2",
+            "nuts1_name": None,
+            "nuts2": "BE24",
+            "nuts2_name": None,
+            "nuts3": "BE241",
+            "nuts3_name": None,
+            "nuts3_confidence": 0.4,
+        },
+    )
+    # main._photon_client is only populated by lifespan(), which runs on
+    # TestClient.__enter__ — so it must be entered before we can patch its
+    # underlying httpx client with the mock transport.
+    with TestClient(main.app) as c:
+        main._photon_client._client = httpx.Client(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(200, json={"features": [{"geometry": {"coordinates": [5.0, 5.0]}}]})
+            )
+        )
+        yield c
+
+
+def test_resolve_weak_geocodes(client):
+    r = client.get(
+        "/resolve",
+        params={"country": "BE", "postal_code": "3080", "street": "Rue", "city": "X"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resolved_via"] == "geocode"
+    assert body["nuts3"] == "DE111"
+    assert body["geocode"]["status"] == "ok"
+
+
+def test_resolve_weak_no_address(client):
+    r = client.get("/resolve", params={"country": "BE", "postal_code": "3080"})
+    assert r.json()["geocode"]["status"] == "no_address"
+    assert r.json()["resolved_via"] == "postal"
+
+
+def test_resolve_does_not_log_address(client, caplog):
+    with caplog.at_level("INFO"):
+        client.get(
+            "/resolve",
+            params={"country": "BE", "postal_code": "3080", "street": "SecretStreet", "city": "SecretCity"},
+        )
+    assert "SecretStreet" not in caplog.text and "SecretCity" not in caplog.text

--- a/tests/test_resolve_endpoint.py
+++ b/tests/test_resolve_endpoint.py
@@ -92,3 +92,27 @@ def test_resolve_does_not_log_address(client, caplog):
             params={"country": "BE", "postal_code": "3080", "street": "SecretStreet", "city": "SecretCity"},
         )
     assert "SecretStreet" not in caplog.text and "SecretCity" not in caplog.text
+
+
+def test_resolve_422_does_not_echo_overlong_street(client):
+    sentinel = "LEAKYSTREET" * 30
+    r = client.get(
+        "/resolve",
+        params={"country": "BE", "postal_code": "3080", "street": sentinel},
+    )
+    assert r.status_code == 422
+    assert sentinel not in r.text
+
+
+def test_lookup_422_body_unaffected(client):
+    # Missing required `country` param — no street/city loc, so the
+    # validation-error handler must leave the body byte-for-byte as FastAPI's
+    # default would produce it (nothing stripped, no Cache-Control header).
+    r = client.get("/lookup", params={"postal_code": "10115"})
+    assert r.status_code == 422
+    body = r.json()
+    errors = body["detail"]
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ["query", "country"]
+    assert "input" in errors[0]
+    assert "Cache-Control" not in r.headers

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -82,6 +82,54 @@ def test_weak_geocode_ok():
     assert r["nuts3_confidence"] is None and r["geocode"]["nuts3"] == "DE111"
 
 
+class FakePipSnap:
+    """PIP whose exact lookup always misses; nearest() returns a configured snap."""
+
+    def __init__(self, snap_res):
+        self._snap = snap_res
+
+    def lookup(self, lat, lon):
+        return None
+
+    def nearest(self, lat, lon, max_km, country=None):
+        return self._snap
+
+
+def _run_snap(snap_res, snap_km):
+    return resolve(
+        "BE",
+        "3080",
+        "Rue",
+        "X",
+        lookup_fn=lambda c, p: WEAK,
+        geocode_fn=lambda s, c, p: (50.0, 4.0),
+        pip=FakePipSnap(snap_res),
+        name_fn=_names,
+        snap_km=snap_km,
+    )
+
+
+def test_snap_recovers_pip_outside():
+    r = _run_snap(
+        {"nuts0": "BE", "nuts1": "BE2", "nuts2": "BE24", "nuts3": "BE242", "snap_km": 0.8},
+        snap_km=2.0,
+    )
+    assert r["resolved_via"] == "geocode" and r["geocode"]["status"] == "snapped"
+    assert r["nuts3"] == "BE242" and r["nuts3_name"] == "name:BE242"
+    assert r["geocode"]["snap_km"] == 0.8 and r["geocode"]["nuts3"] == "BE242"
+
+
+def test_snap_miss_stays_pip_outside():
+    r = _run_snap(None, snap_km=2.0)
+    assert r["geocode"]["status"] == "pip_outside" and r["resolved_via"] == "postal"
+
+
+def test_snap_disabled_by_default_is_pip_outside():
+    # default snap_km=0 must not even call pip.nearest (FakePip has none)
+    r = _run(WEAK, pip_res=None)
+    assert r["geocode"]["status"] == "pip_outside"
+
+
 def test_not_found_no_address_is_none():
     r = _run(None, street=None, city=None)
     assert r["resolved_via"] == "none" and r["match_type"] == "not_found"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,88 @@
+"""Tests for app/resolver.py cascade (pure, no HTTP)."""
+
+from app.resolver import resolve
+
+STRONG = {
+    "match_type": "exact",
+    "nuts1": "BE2",
+    "nuts1_name": "Vl",
+    "nuts2": "BE24",
+    "nuts2_name": "VlB",
+    "nuts3": "BE241",
+    "nuts3_name": "Halle",
+    "nuts3_confidence": 1.0,
+}
+WEAK = {**STRONG, "match_type": "approximate", "nuts3_confidence": 0.5}
+
+
+class FakePip:
+    def __init__(self, res):
+        self._res = res
+
+    def lookup(self, lat, lon):
+        return self._res
+
+
+def _names(code):
+    return f"name:{code}"
+
+
+def _run(
+    current,
+    street="Rue",
+    city="X",
+    pip_res=None,
+    geocode=lambda s, c, p: (50.0, 4.0),
+    geocode_fn_none=False,
+):
+    return resolve(
+        "BE",
+        "3080",
+        street,
+        city,
+        lookup_fn=lambda c, p: current,
+        geocode_fn=None if geocode_fn_none else geocode,
+        pip=FakePip(pip_res),
+        name_fn=_names,
+    )
+
+
+def test_strong_postal_no_geocode():
+    r = _run(STRONG)
+    assert r["resolved_via"] == "postal" and r["geocode"]["status"] == "not_attempted"
+    assert r["nuts3"] == "BE241"
+
+
+def test_weak_no_address():
+    r = _run(WEAK, street=None, city=None)
+    assert r["geocode"]["status"] == "no_address" and r["resolved_via"] == "postal"
+    assert r["nuts3"] == "BE241"  # best-effort postal still returned
+
+
+def test_weak_geocoder_unavailable():
+    r = _run(WEAK, geocode_fn_none=True)
+    assert r["geocode"]["status"] == "geocoder_unavailable" and r["resolved_via"] == "postal"
+
+
+def test_weak_geocode_no_result():
+    r = _run(WEAK, geocode=lambda s, c, p: None)
+    assert r["geocode"]["status"] == "no_result" and r["resolved_via"] == "postal"
+
+
+def test_weak_pip_outside():
+    r = _run(WEAK, pip_res=None)  # geocode ok, pip miss
+    assert r["geocode"]["status"] == "pip_outside"
+    assert r["geocode"]["lat"] == 50.0 and r["resolved_via"] == "postal"
+
+
+def test_weak_geocode_ok():
+    r = _run(WEAK, pip_res={"nuts0": "DE", "nuts1": "DE1", "nuts2": "DE11", "nuts3": "DE111"})
+    assert r["resolved_via"] == "geocode" and r["geocode"]["status"] == "ok"
+    assert r["nuts3"] == "DE111" and r["nuts3_name"] == "name:DE111"
+    assert r["nuts3_confidence"] is None and r["geocode"]["nuts3"] == "DE111"
+
+
+def test_not_found_no_address_is_none():
+    r = _run(None, street=None, city=None)
+    assert r["resolved_via"] == "none" and r["match_type"] == "not_found"
+    assert r["nuts3"] is None and r["geocode"]["status"] == "no_address"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -76,10 +76,17 @@ def test_weak_pip_outside():
 
 
 def test_weak_geocode_ok():
-    r = _run(WEAK, pip_res={"nuts0": "DE", "nuts1": "DE1", "nuts2": "DE11", "nuts3": "DE111"})
+    r = _run(WEAK, pip_res={"nuts0": "BE", "nuts1": "BE2", "nuts2": "BE24", "nuts3": "BE242"})
     assert r["resolved_via"] == "geocode" and r["geocode"]["status"] == "ok"
-    assert r["nuts3"] == "DE111" and r["nuts3_name"] == "name:DE111"
-    assert r["nuts3_confidence"] is None and r["geocode"]["nuts3"] == "DE111"
+    assert r["nuts3"] == "BE242" and r["nuts3_name"] == "name:BE242"
+    assert r["nuts3_confidence"] is None and r["geocode"]["nuts3"] == "BE242"
+
+
+def test_cross_country_pip_hit_rejected():
+    # geocode lands inside a DE polygon but the request is for BE → reject, don't return DE
+    r = _run(WEAK, pip_res={"nuts0": "DE", "nuts1": "DE1", "nuts2": "DE11", "nuts3": "DE111"})
+    assert r["geocode"]["status"] == "pip_outside"
+    assert r["resolved_via"] == "postal" and r["nuts3"] == "BE241"
 
 
 class FakePipSnap:

--- a/tests/test_tier_gating.py
+++ b/tests/test_tier_gating.py
@@ -1,0 +1,51 @@
+"""Tier gating: NUTS polygons load only when a Photon geocoder is configured."""
+
+import importlib
+import json
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+
+def _reload_app(monkeypatch, photon_url, geojson_path=""):
+    monkeypatch.setenv("PC2NUTS_PHOTON_URL", photon_url)
+    monkeypatch.setenv("PC2NUTS_NUTS_GEOJSON_PATH", geojson_path)
+    monkeypatch.setenv("PC2NUTS_TOKEN_DB_URL", "")
+    monkeypatch.setenv("PC2NUTS_ESTIMATES_REFRESH_URL", "")
+    import app.config as cfg
+    importlib.reload(cfg)
+    import app.main as main
+    importlib.reload(main)
+    return main
+
+
+def test_lite_mode_skips_polygon_load(monkeypatch):
+    main = _reload_app(monkeypatch, photon_url="")
+    spy = MagicMock()
+    monkeypatch.setattr(main, "load_nuts_pip", spy)
+    with TestClient(main.app) as tc:
+        body = tc.get("/health").json()
+    spy.assert_not_called()               # no ~160 MB polygon download in Lite
+    assert body["pip_ready"] is False
+    assert body["geocoder_configured"] is False
+
+
+def test_full_mode_loads_polygons(monkeypatch, tmp_path):
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"NUTS_ID": "DE111", "LEVL_CODE": 3},
+                "geometry": {"type": "Polygon",
+                             "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]},
+            }
+        ],
+    }
+    p = tmp_path / "nuts.geojson"
+    p.write_text(json.dumps(geojson))
+    main = _reload_app(monkeypatch, photon_url="http://photon", geojson_path=str(p))
+    with TestClient(main.app) as tc:
+        body = tc.get("/health").json()
+    assert body["pip_ready"] is True
+    assert body["geocoder_configured"] is True


### PR DESCRIPTION
Publishes the address→geocode→NUTS `/resolve` cascade and documents a deploy-time
choice between two tiers, from one codebase and image:

- **Lite** (default, `PC2NUTS_PHOTON_URL` unset): postal-code → NUTS only. Now skips
  the ~160 MB NUTS-polygon load entirely, so it stays lightweight.
- **Full** (`PC2NUTS_PHOTON_URL` set): adds an address → komoot-Photon → point-in-polygon
  fallback for weak postal results, a country-guarded nearest-polygon snap for
  coastline/border points, and postal-code sanitization for malformed inputs.

Includes:
- `GET /resolve` cascade (`app/resolver.py`, `app/nuts_pip.py`, `app/nuts_polygons.py`,
  `app/photon_client.py`) with a cross-border guard so a mis-geocode can't return a
  wrong-country NUTS.
- `compose.full.yaml` override and README "Deployment tiers" + `/resolve` reference.
- `/health` reports `pip_ready` and `geocoder_configured` so the active tier is visible.

Full test suite green.