### PR TITLE
fix: harden Photon client + consistent lifespan settings (#125, #126, #127)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -123,13 +123,13 @@ async def lifespan(app: FastAPI):
     # PIP is only useful with a geocoder to produce coordinates, so the ~160 MB
     # polygon load is skipped entirely in the Lite tier (no PC2NUTS_PHOTON_URL).
     global _nuts_pip, _photon_client, _geo_http
-    if settings.photon_url:
+    if _config.settings.photon_url:
         try:
             with _httpx.Client() as _dl_client:
                 _nuts_pip = load_nuts_pip(
-                    url=settings.nuts_geojson_url,
-                    path=settings.nuts_geojson_path,
-                    cache_dir=settings.data_dir,
+                    url=_config.settings.nuts_geojson_url,
+                    path=_config.settings.nuts_geojson_path,
+                    cache_dir=_config.settings.data_dir,
                     client=_dl_client,
                 )
             logger.info("NUTS polygons loaded — /resolve PIP ready.")

--- a/app/photon_client.py
+++ b/app/photon_client.py
@@ -35,8 +35,6 @@ class PhotonClient:
             out.append(f"{postal_code} {city}")
         if city:
             out.append(city)
-        if street and postal_code and not city:
-            out.append(f"{street}, {postal_code}")
         if postal_code:
             out.append(postal_code)
         if street and not city and not postal_code:
@@ -53,15 +51,17 @@ class PhotonClient:
             )
             resp.raise_for_status()
             data = resp.json()
-        except (httpx.HTTPError, ValueError):
+            feats = data.get("features") or []
+            if not feats:
+                return None
+            coords = (feats[0].get("geometry") or {}).get("coordinates") or []
+            if len(coords) < 2:
+                return None
+            # (lat, lon) from [lon, lat]; a non-Point feature nests coordinates,
+            # so float() would raise TypeError — caught here to honour "never raises".
+            return (float(coords[1]), float(coords[0]))
+        except (httpx.HTTPError, ValueError, TypeError, IndexError):
             return None
-        feats = data.get("features") or []
-        if not feats:
-            return None
-        coords = (feats[0].get("geometry") or {}).get("coordinates") or []
-        if len(coords) < 2:
-            return None
-        return (float(coords[1]), float(coords[0]))  # (lat, lon) from [lon, lat]
 
     def geocode(
         self, street: str | None, city: str | None, postal_code: str | None

--- a/tests/test_photon_client.py
+++ b/tests/test_photon_client.py
@@ -62,6 +62,32 @@ def test_never_combines_street_and_postcode():
     assert all(not ("Museumpark 25" in q and "3000 AE" in q) for q in seen)
 
 
+def test_never_combines_street_and_postcode_without_city():
+    # The no-city path (reachable via the offline enrich path) must also never
+    # put street and postcode in one query — Photon returns nothing for that pair.
+    seen = []
+
+    def handler(req):
+        seen.append(req.url.params["q"])
+        return httpx.Response(200, json={"features": []})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    pc.geocode("Museumpark 25", "", "3000 AE")
+    assert seen, "expected at least one query"
+    assert all(not ("Museumpark 25" in q and "3000 AE" in q) for q in seen)
+
+
+def test_non_point_geometry_returns_none():
+    # A non-Point feature has nested coordinates (e.g. [[lon,lat],...]); parsing
+    # coords[1] as a float would raise TypeError. The contract is "never raises".
+    def handler(req):
+        geom = {"type": "LineString", "coordinates": [[4.5, 50.8], [4.6, 50.9]]}
+        return httpx.Response(200, json={"features": [{"geometry": geom}]})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    assert pc.geocode("Markt", "Tervuren", "3080") is None
+
+
 def test_all_queries_empty_returns_none():
     pc = PhotonClient("http://photon", _client(lambda r: httpx.Response(200, json={"features": []})))
     assert pc.geocode("X", "Y", "0000") is None


### PR DESCRIPTION
Resolves the three findings from the pre-publish whole-branch review of #123, all in the new Photon geocoding code.

## Changes

- **#125** — `PhotonClient._candidates` no longer appends `street, postal_code` as a candidate when `city` is empty. Both docstrings state street and postcode are *never* combined (Photon returns nothing for that pair); the offline enrich path could pass an empty `city` and trigger it, wasting the first Photon round-trip. Docstring "never" claim is now accurate.
- **#126** — `PhotonClient._query` now parses coordinates *inside* the `try/except` and catches `(TypeError, IndexError)`. A non-Point feature has nested `coordinates`, so `float(coords[1])` raised `TypeError` and propagated a 500 out of `geocode()`, contradicting the documented "never raises → None" contract.
- **#127** — the lifespan NUTS-polygon block now reads `_config.settings.*` (matching the adjacent Photon and token-DB blocks) instead of the module-level `settings.*`, so a monkeypatch of `_config.settings` without a module reload can't desync PIP vs. geocoder.

## Tests

- Added `test_never_combines_street_and_postcode_without_city` (the no-city path #125's existing test didn't cover).
- Added `test_non_point_geometry_returns_none` (#126).
- `tests/test_photon_client.py` — 10/10 pass, ruff clean. No new failures vs. `main` (the shapely-gated suites are unaffected by these changes and run in CI).

Closes #125
Closes #126
Closes #127