### PR TITLE
chore(deps): bundle Dependabot bumps (uvicorn 0.51.0, shapely 2.1.2), sync lock

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -27,7 +27,7 @@ slowapi==0.1.10
 starlette==1.3.1
 typing-inspection==0.4.2
 typing_extensions==4.16.0
-uvicorn==0.49.0
+uvicorn==0.51.0
 uvloop==0.22.1
 watchfiles==1.2.0
 websockets==16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 fastapi>=0.139.0,<1
-uvicorn[standard]>=0.49.0,<1
+uvicorn[standard]>=0.51.0,<1
 httpx>=0.28.1,<1
 pydantic>=2.13.4,<3
 pydantic-settings>=2.14.2,<3
 slowapi>=0.1.10,<1
 limits[redis]>=5.8.0
 # Point-in-polygon NUTS resolution for /resolve (pulls numpy transitively)
-shapely>=2.0,<3
+shapely>=2.1.2,<3
 python-dotenv>=1.2.2,<2
 # Transitive (via httpx); pinned to clear CVE-2026-45409
 idna>=3.18,<4


### PR DESCRIPTION
Bundles #137 and #138, plus the `requirements.lock` update neither can make.

## Why bundle

The Docker image installs from `requirements.lock`, not `requirements.txt`. Merging #138 alone would declare `uvicorn>=0.51.0` while continuing to ship `uvicorn==0.49.0` in the image. CI does not catch this: `test`/`import-check` install `requirements.txt` (resolving 0.51.0) while `docker` builds from the lock (0.49.0), so both jobs pass green and the drift ships.

- **shapely** — floor bump only; the lock already pins `2.1.2` (since 97fcefb).
- **uvicorn** — floor bump **and** `requirements.lock`: `0.49.0` -> `0.51.0`.

## Upgrade risk review

No transitive changes are needed. Checked against uvicorn 0.51.0 PyPI metadata rather than the changelog prose: the lock’s `websockets==16.0` (>= new 13.0 floor), `httptools==0.8.0`, `uvloop`, `watchfiles`, `PyYAML`, `click` and `h11` all satisfy it, and `colorama` was never in the lock, so its removal from the `standard` extra is a no-op.

- **`--ws auto` now defaults to websockets-sansio (0.50.0)** — inert; the app has no websocket routes.
- **Supervisor exits on startup failure instead of restarting forever (0.50.0)** — relevant because the Dockerfile runs `--workers ${PC2NUTS_WORKERS:-1}`. Every startup path that can fail transiently already catches its own exceptions: `refresh_db_tokens` swallows all exceptions (`app/auth.py:139`), and the NUTS polygon load and estimates bootstrap are each wrapped in `try/except`. Only `load_data()` (`app/main.py:105`) can propagate, and only on a genuinely broken image — where fail-fast is the desired behavior.

## Verification

With the updated lock actually installed (not just resolved):

- `pytest` — 393 passed
- `pip-audit -r requirements.lock` — no known vulnerabilities
- `ruff check` / `ruff format --check` — clean
- Booted the real Dockerfile command (`uvicorn app.main:app --workers 1 --proxy-headers ...`): `/health` served 830,032 postal codes, a live `PL 00-001` lookup returned the expected NUTS3 `PL911`, clean SIGTERM shutdown.

The boot check matters because the test suite uses `TestClient`, which never starts uvicorn — the suite alone cannot exercise a uvicorn upgrade.

Closes #137
Closes #138