### PR TITLE
chore(deps): bundle Dependabot bumps (fastapi 0.141.1, uvicorn 0.52.0, ruff 0.16.0), sync lock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-ruff>=0.15.22,<1
+ruff>=0.16.0,<1
 bandit>=1.9.4,<2
 pip-audit>=2.10.1,<3
 pytest>=9.1.1,<10

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,20 +1,20 @@
 # Pinned dependencies for reproducible production builds.
 # Generated from requirements.txt — update by running:
 #   pip install -r requirements.txt && pip freeze > requirements.lock
-annotated-doc==0.0.4
-annotated-types==0.7.0
-anyio==4.14.1
-certifi==2026.6.17
+annotated-doc==0.0.5
+annotated-types==0.8.0
+anyio==4.14.2
+certifi==2026.7.22
 click==8.4.2
 Deprecated==1.3.1
-fastapi==0.139.2
+fastapi==0.141.1
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.8.0
 httpx==0.28.1
 idna==3.18
 limits==5.8.0
-numpy==2.5.0
+numpy==2.5.1
 packaging==26.2
 pydantic==2.13.4
 pydantic-settings==2.14.2
@@ -27,8 +27,8 @@ slowapi==0.1.10
 starlette==1.3.1
 typing-inspection==0.4.2
 typing_extensions==4.16.0
-uvicorn==0.51.0
+uvicorn==0.52.0
 uvloop==0.22.1
 watchfiles==1.2.0
-websockets==16.0
-wrapt==2.2.2
+websockets==17.0
+wrapt==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fastapi>=0.139.2,<1
-uvicorn[standard]>=0.51.0,<1
+fastapi>=0.141.1,<1
+uvicorn[standard]>=0.52.0,<1
 httpx>=0.28.1,<1
 pydantic>=2.13.4,<3
 pydantic-settings>=2.14.2,<3


### PR DESCRIPTION
Bundles #144, #145 and #146 into one review, and — critically — syncs `requirements.lock`.

## Why bundle

Each Dependabot PR bumps only the requirement *range*. None touch `requirements.lock`, which is the file the production image installs from (`Dockerfile:12-13`). Merging them as-is would leave the repo self-contradictory: `requirements.txt` demanding `fastapi>=0.141.1` while the lock still pinned `fastapi==0.139.2` — a pin below its own declared floor — and the shipped image would keep building the old version.

## Changes

| File | Change |
|---|---|
| `requirements.txt` | fastapi `>=0.139.2` → `>=0.141.1`; uvicorn[standard] `>=0.51.0` → `>=0.52.0` |
| `requirements-dev.txt` | ruff `>=0.15.22` → `>=0.16.0` |
| `requirements.lock` | regenerated from a clean venv |

The lock was regenerated with the documented procedure (`pip install -r requirements.txt && pip freeze`), so besides fastapi and uvicorn it also picks up transitive drift: annotated-doc 0.0.5, annotated-types 0.8.0, anyio 4.14.2, certifi 2026.7.22, numpy 2.5.1, websockets 17.0, wrapt 2.3.0.

Note `websockets` crosses a major boundary (16.0 → 17.0). It arrives via `uvicorn[standard]` and is exercised by the image build and smoke test below.

## Verification

All CI-equivalent checks run locally against the regenerated lock:

- `ruff check app/ scripts/` (ruff 0.16.0) — All checks passed
- `ruff format --check app/ scripts/` — 24 files already formatted
- `python -c "from app.main import app"` — imports OK
- `pytest tests/ -q` — **393 passed**
- `pip-audit -r requirements.lock` — No known vulnerabilities found
- `bandit -r app/ -c pyproject.toml` — 0 issues at every severity
- `docker build` — succeeds
- Container smoke test — `/health` 200 with 830,033 postal codes loaded; `/lookup` correct for PL 00-001 (approximate) and DE 10115 (exact)

Closes #144
Closes #145
Closes #146