### PR TITLE
chore: group Dependabot version updates to cut PR churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,40 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Grouped so a week's bumps arrive as one reviewable PR instead of one per
+    # package. Production and development are kept apart because they carry
+    # different follow-up work: production bumps also need requirements.lock
+    # regenerated (Dependabot cannot do this — it only scans requirements*.txt,
+    # so the .lock is always a manual step) plus a prod redeploy, while dev-only
+    # bumps (ruff, pytest) are self-contained.
+    groups:
+      python-production:
+        applies-to: version-updates
+        dependency-type: "production"
+        patterns:
+          - "*"
+      python-development:
+        applies-to: version-updates
+        dependency-type: "development"
+        patterns:
+          - "*"
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      docker:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes the churn at the source rather than bundling it by hand each week.

## Problem

`dependabot.yml` had no `groups:` key, so every package got its own weekly PR and its own notification — three this week (#144, #145, #146), all superseded by the manual bundle in #147.

## Change

One group per ecosystem, with pip split production/development:

| Ecosystem | Groups | PRs per week (was) |
|---|---|---|
| pip | `python-production`, `python-development` | ≤2 (one per outdated package) |
| docker | `docker` | ≤1 |
| github-actions | `github-actions` | ≤1 |

The pip split is deliberate: the two halves carry different follow-up work. A production bump also needs `requirements.lock` regenerated and a prod redeploy; a dev-only bump (ruff, pytest) is self-contained and mergeable on sight. Lumping them together would drag trivial dev bumps into the slower production review path.

Every group is scoped `applies-to: version-updates`, so **security** updates keep arriving individually and immediately instead of waiting to be batched into the weekly PR.

## Known limitation

This does not make Dependabot maintain `requirements.lock`. Dependabot's pip ecosystem only scans `requirements*.txt` (plus `pyproject.toml`/`setup.py`/`Pipfile`), and `requirements.lock` matches none of those patterns — so the lock regen stays a manual step on production bumps, exactly as in #147. Grouping reduces that to one lock sync per week instead of one per package.

## Verification

`dependabot.yml` parses as valid YAML and every group key/value was checked against the Dependabot schema — `applies-to` ∈ {version-updates, security-updates}, `dependency-type` ∈ {production, development}, no unknown keys. GitHub validates the config itself once this lands on the default branch.