### PR TITLE
chore(deps): bundle Dependabot bumps (uvicorn 0.52.1, ruff 0.16.1), sync lock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-ruff>=0.16.0,<1
+ruff>=0.16.1,<1
 bandit>=1.9.4,<2
 pip-audit>=2.10.1,<3
 pytest>=9.1.1,<10

--- a/requirements.lock
+++ b/requirements.lock
@@ -15,7 +15,7 @@ httpx==0.28.1
 idna==3.18
 limits==5.8.0
 numpy==2.5.1
-packaging==26.2
+packaging==26.3
 pydantic==2.13.4
 pydantic-settings==2.14.2
 pydantic_core==2.46.4
@@ -24,11 +24,11 @@ PyYAML==6.0.3
 redis==7.4.1
 shapely==2.1.2
 slowapi==0.1.10
-starlette==1.3.1
+starlette==1.4.1
 typing-inspection==0.4.2
 typing_extensions==4.16.0
-uvicorn==0.52.0
+uvicorn==0.52.1
 uvloop==0.22.1
 watchfiles==1.2.0
-websockets==17.0
+websockets==17.0.1
 wrapt==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi>=0.141.1,<1
-uvicorn[standard]>=0.52.0,<1
+uvicorn[standard]>=0.52.1,<1
 httpx>=0.28.1,<1
 pydantic>=2.13.4,<3
 pydantic-settings>=2.14.2,<3


### PR DESCRIPTION
Supersedes #149 (ruff) and #150 (uvicorn). Both Dependabot PRs bump only the requirement range in `requirements*.txt` and leave `requirements.lock` — the file the production image installs from — pinned to the old version, so neither is mergeable on its own without a follow-up lock sync.

## Changes

- `requirements.txt`: `uvicorn[standard]>=0.52.0,<1` → `>=0.52.1,<1`
- `requirements-dev.txt`: `ruff>=0.16.0,<1` → `>=0.16.1,<1`
- `requirements.lock` regenerated from a clean `python:3.14-slim` container (the runtime base image): `uvicorn` 0.52.1, plus transitive drift `packaging` 26.3, `starlette` 1.3.1 → 1.4.1, `websockets` 17.0 → 17.0.1

uvicorn 0.52.1 is a WebSocket-only bugfix release (closing handshake, write flow control, denial-response headers). This service exposes no WebSocket endpoints, so it is a no-op here beyond staying current.

## Verification

Run against the regenerated lock in `python:3.14-slim`:

- `pytest` — 393 passed
- `pip-audit -r requirements.lock` — no known vulnerabilities
- `ruff 0.16.1 check app/ scripts/` + `ruff format --check app/ scripts/` — clean

Note: starlette 1.4.x emits a new `StarletteDeprecationWarning` for `TestClient` with `httpx` (suggests `httpx2`). Warning only — no failures, no production impact.