### PR TITLE
feat(deps): migrate HTTP client from httpx to httpx2

### DIFF
--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-import httpx
+import httpx2 as httpx
 
 from app.albania_blocks import SUPPORTED as AL_SUPPORTED
 from app.albania_blocks import resolve_al_block

--- a/app/estimates_refresh.py
+++ b/app/estimates_refresh.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-import httpx
+import httpx2 as httpx
 
 from app.config import settings
 from app.data_loader import _data_lock, _estimates, _revalidate_estimates, parse_estimates_from_text

--- a/app/main.py
+++ b/app/main.py
@@ -46,7 +46,7 @@ from app.nuts_polygons import load_nuts_pip
 from app.photon_client import PhotonClient
 from app.postal_patterns import PATTERNS_META, POSTAL_PATTERNS
 from app.resolver import resolve as _resolve
-import httpx as _httpx
+import httpx2 as _httpx
 
 logging.basicConfig(
     level=logging.INFO,
@@ -54,10 +54,13 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# httpx logs full outbound request URLs (including query strings) at INFO.
+# httpx2 logs full outbound request URLs (including query strings) at INFO.
 # /resolve sends street/city to the Photon geocoder as query params, so at
-# INFO level httpx would leak that PII into our logs — quiet it to WARNING.
-logging.getLogger("httpx").setLevel(logging.WARNING)
+# INFO level httpx2 would leak that PII into our logs — quiet it to WARNING.
+# The logger name is taken from the module rather than hardcoded: it is the
+# client library's own name ("httpx2"), so swapping the client again cannot
+# leave this silencing a logger nobody writes to while the PII leak reopens.
+logging.getLogger(_httpx.__name__).setLevel(logging.WARNING)
 
 _nuts_pip = None  # app.nuts_pip.NutsPip once polygons load
 _photon_client = None  # app.photon_client.PhotonClient when PC2NUTS_PHOTON_URL set

--- a/app/nuts_polygons.py
+++ b/app/nuts_polygons.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import httpx
+import httpx2 as httpx
 
 from app.nuts_pip import NutsPip, load_nuts3_features
 
@@ -23,7 +23,7 @@ def load_nuts_pip(*, url: str, path: str, cache_dir: str, client: httpx.Client |
     cache = Path(cache_dir) / _CACHE_NAME
     if not cache.exists():
         if client is None:
-            raise ValueError("no cached polygons and no httpx client to download them")
+            raise ValueError("no cached polygons and no HTTP client to download them")
         cache.parent.mkdir(parents=True, exist_ok=True)
         resp = client.get(url, timeout=120, follow_redirects=True)
         resp.raise_for_status()

--- a/app/photon_client.py
+++ b/app/photon_client.py
@@ -16,7 +16,7 @@ the correct NUTS-3 region.
 
 from __future__ import annotations
 
-import httpx
+import httpx2 as httpx
 
 
 class PhotonClient:

--- a/app/token_db.py
+++ b/app/token_db.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import httpx
+import httpx2 as httpx
 
 
 class TokenDBError(Exception):

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,14 +4,13 @@
 annotated-doc==0.0.5
 annotated-types==0.8.0
 anyio==4.14.2
-certifi==2026.7.22
 click==8.4.2
 Deprecated==1.3.1
 fastapi==0.141.1
 h11==0.16.0
-httpcore==1.0.9
+httpcore2==2.10.0
 httptools==0.8.0
-httpx==0.28.1
+httpx2==2.10.0
 idna==3.18
 limits==5.8.0
 numpy==2.5.2
@@ -25,6 +24,7 @@ redis==7.4.1
 shapely==2.1.2
 slowapi==0.1.10
 starlette==1.6.0
+truststore==0.10.4
 typing-inspection==0.4.4
 typing_extensions==4.16.0
 uvicorn==0.52.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.141.1,<1
 uvicorn[standard]>=0.52.1,<1
-httpx>=0.28.1,<1
+httpx2>=2.10.0,<3
 pydantic>=2.13.4,<3
 pydantic-settings>=2.15.0,<3
 slowapi>=0.1.10,<1
@@ -8,5 +8,5 @@ limits[redis]>=5.8.0
 # Point-in-polygon NUTS resolution for /resolve (pulls numpy transitively)
 shapely>=2.1.2,<3
 python-dotenv>=1.2.2,<2
-# Transitive (via httpx); pinned to clear CVE-2026-45409
+# Transitive (via httpx2); pinned to clear CVE-2026-45409
 idna>=3.18,<4

--- a/scripts/enrich_via_api.py
+++ b/scripts/enrich_via_api.py
@@ -23,7 +23,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-import httpx
+import httpx2 as httpx
 
 OUT_FIELDS = [
     "OID",

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,6 +1,6 @@
 """Tests for data_loader.py — normalize functions and lookup tiers."""
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 from app import data_loader

--- a/tests/test_estimates_refresh.py
+++ b/tests/test_estimates_refresh.py
@@ -4,7 +4,7 @@ import asyncio
 import hashlib
 import importlib
 
-import httpx
+import httpx2 as httpx
 import pytest
 
 

--- a/tests/test_http_logging.py
+++ b/tests/test_http_logging.py
@@ -1,0 +1,37 @@
+"""Tests that the HTTP client library's request logging stays quieted.
+
+The HTTP client logs full outbound request URLs (including query strings) at
+INFO. /resolve forwards street/city to the Photon geocoder as query params, so
+at INFO level those logs would leak PII. app/main.py quiets that logger to
+WARNING by name — and a logger name is a string, so if the client library is
+ever swapped for one that logs under a different name, the guard silently stops
+applying and the leak reappears with nothing failing. These tests pin the guard
+to the library actually in use.
+"""
+
+import logging
+
+import httpx2 as httpx
+
+
+def test_http_client_logger_is_quieted_to_warning():
+    import app.main  # noqa: F401  — import applies the logging configuration
+
+    assert logging.getLogger(httpx.__name__).level >= logging.WARNING
+
+
+def test_request_url_with_query_params_is_not_logged_at_info(caplog):
+    """A geocode-shaped request must not emit its query string into the logs."""
+    import app.main  # noqa: F401  — import applies the logging configuration
+
+    def handler(request):
+        return httpx.Response(200, json={"features": []})
+
+    with caplog.at_level(logging.INFO):
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            client.get("http://photon/api", params={"q": "Rue Secrete, Bruxelles"})
+
+    # Assert on a token that survives URL encoding: the logged line renders the
+    # query as "q=Rue+Secrete%2C+Bruxelles", so asserting on the unencoded
+    # "Rue Secrete" would pass even when the address IS being logged.
+    assert "Secrete" not in caplog.text

--- a/tests/test_nuts_polygons.py
+++ b/tests/test_nuts_polygons.py
@@ -2,7 +2,7 @@
 
 import json
 
-import httpx
+import httpx2 as httpx
 
 from app.nuts_polygons import load_nuts_pip
 

--- a/tests/test_photon_client.py
+++ b/tests/test_photon_client.py
@@ -1,6 +1,6 @@
 """Tests for app/photon_client.py."""
 
-import httpx
+import httpx2 as httpx
 
 from app.photon_client import PhotonClient
 

--- a/tests/test_resolve_endpoint.py
+++ b/tests/test_resolve_endpoint.py
@@ -3,7 +3,7 @@
 import importlib
 import json
 
-import httpx
+import httpx2 as httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -57,7 +57,7 @@ def client(tmp_path, monkeypatch):
     )
     # main._photon_client is only populated by lifespan(), which runs on
     # TestClient.__enter__ — so it must be entered before we can patch its
-    # underlying httpx client with the mock transport.
+    # underlying HTTP client with the mock transport.
     with TestClient(main.app) as c:
         main._photon_client._client = httpx.Client(
             transport=httpx.MockTransport(

--- a/tests/test_token_db.py
+++ b/tests/test_token_db.py
@@ -88,7 +88,7 @@ class TestTokenDBExecute:
 
             def raise_for_status(self):
                 if self.status_code >= 400:
-                    import httpx
+                    import httpx2 as httpx
 
                     raise httpx.HTTPStatusError("boom", request=None, response=self)
 
@@ -100,7 +100,7 @@ class TestTokenDBExecute:
             captured["headers"] = headers
             return _Response(json_body, status_code)
 
-        import httpx
+        import httpx2 as httpx
 
         monkeypatch.setattr(httpx.Client, "post", _post)
         return captured


### PR DESCRIPTION
Migrates the HTTP client from `httpx` to `httpx2`, clearing the `StarletteDeprecationWarning` introduced by starlette 1.6.0 (#155).

`starlette.testclient` now does `import httpx2` and falls back to `httpx` with a deprecation warning. `httpx2` is the successor from Tom Christie (httpx's own author, now under `pydantic/httpx2`) and carries every symbol this repo uses — `Client`, `AsyncClient`, `Response`, `MockTransport`, `HTTPError`, `RequestError`, `HTTPStatusError` — with an unchanged `Client.__init__` signature.

### Approach
Modules use `import httpx2 as httpx`, which is what starlette does internally. Every `client: httpx.Client` annotation and `except httpx.HTTPError` stays as-is, so the diff is one line per module instead of ~40 renamed references.

### The part that mattered: a silently-breaking PII guard
`app/main.py` quiets the client's request logging because httpx logs full outbound URLs at INFO, and `/resolve` sends street/city to Photon as query params.

**httpx2 logs under the logger name `"httpx2"`.** The existing `logging.getLogger("httpx")` would have kept silencing a logger nothing writes to, while addresses resumed flowing into production logs at INFO — with no test failing and no error raised.

The name is now derived from the imported module, so a future client swap cannot reopen this. `tests/test_http_logging.py` (written first, confirmed failing against the pre-fix code) pins both the logger level and the absence of the address from captured output. Note the second test asserts on a token that survives URL encoding — the logged line renders `q=Rue+Secrete%2C+Bruxelles`, so asserting on the unencoded string would have passed while leaking.

### TLS: verified, not assumed
httpx2 drops `certifi` for `truststore`, moving verification to the OS trust store — a runtime-only change that `MockTransport` tests can never exercise, since they open no sockets. Checked against the actual built image:

- real HTTPS GET to `gisco-services.ec.europa.eu` → **200, 89,384 bytes**
- `https://expired.badssl.com/` → **rejected** (`ConnectError`), so verification is active, not permissive

### Lockfile
Regenerated in `python:3.14-slim`: `-certifi`, `httpcore`→`httpcore2`, `httpx`→`httpx2`, `+truststore`.

### Verification
- `pytest` — **395 passed** (393 + 2 new), starlette deprecation warning gone from the summary
- `ruff check` / `ruff format --check` on `app/ scripts/` — clean
- `pip-audit -r requirements.lock` — no known vulnerabilities
- `bandit -r app/` — clean
- container smoke test — `/health` 200 with 830,033 postal codes loaded; httpx2 logger confirmed at WARNING inside the running image

Production dependency change, so this needs a redeploy once `publish` runs.