### PR TITLE
feat!: rename the `territory` response block to `context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ route always answers `200`, carrying a `found` flag and a human-readable
 - **BREAKING** `NUTSResult`, `PatternResponse` and `ResolveResponse` gain `found`
   (bool) and `message` (string or null). `PatternResponse.regex` and
   `PatternResponse.example` are now nullable.
+- **BREAKING** the `territory` block on `/lookup` and `/resolve` is renamed to
+  `context`, and the `TerritoryInfo` model to `ContextInfo`. The block covers three
+  kinds of place - outermost regions (integral parts of a Member State), overseas
+  countries and territories (several of them constituent countries) and other
+  European areas such as the Crown Dependencies - so naming it for one of them
+  described the other two wrongly. Field names inside the block are unchanged,
+  `status` included; only the key and the model name move.
 - `422` (unparseable parameters), `429` (rate limit) and `401` (invalid token) are
   unchanged - they describe the request, not the data.
 - OpenAPI `responses` for the three endpoints updated to document the 200-only
@@ -90,7 +97,8 @@ route always answers `200`, carrying a `found` flag and a human-readable
 
 ### Migration
 
-Replace `if r.status_code == 404` (and `== 400`) with `if not r.json()["found"]`.
+Replace `if r.status_code == 404` (and `== 400`) with `if not r.json()["found"]`,
+and read `body["context"]` where you read `body["territory"]`.
 A partial hit - a recognised code in a territory outside NUTS, e.g. `FO/100` - keeps
 `found: true` and carries a `message` explaining the null `nuts*` fields, so a client
 that only checks `found` behaves as before for those.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ was already supported, and 59 country codes are now accepted in total (60 with U
 configured — see [United Kingdom (ITL)](#united-kingdom-itl)). The Canary Islands, Azores and Madeira have
 no ISO alpha-2 code and are reached only through `ES` and `PT` postal codes.
 
-Every result inside a listed territory carries a `territory` block; results elsewhere carry
-`territory: null`. See [`docs/overseas_territories.md`](docs/overseas_territories.md) for the
+Every result inside a listed area carries a `context` block; results elsewhere carry
+`context: null`. See [`docs/overseas_territories.md`](docs/overseas_territories.md) for the
 complete lists and per-territory behaviour.
 
 ### United Kingdom (ITL)
@@ -69,7 +69,7 @@ ITL is **not** a drop-in for NUTS-2016 UK: it diverges at L2 (41 vs 40 regions) 
 
 UK coverage is **optional and operator-configured** — the ~178 MB NSPL ZIP is not bundled. When `PC2NUTS_NSPL_URL` is unset (the default), UK is not served and `/lookup` answers `200` with `found: false`. Outward-code-only input (e.g. `SW1A`) resolves to the majority ITL3 for that outward code with `estimated`/medium confidence.
 
-> **Out of scope for ITL:** Crown Dependencies (Jersey JE, Guernsey GG, Isle of Man IM) and Gibraltar (GI) use UK-style postcodes but are not in ITL geography or NSPL. They are registered territories (see [Overseas regions and territories](#overseas-regions-and-territories)): a well-formed UK-pattern code returns `200` with a `territory` block and `nuts_coverage: "none"`, not an ITL result.
+> **Out of scope for ITL:** Crown Dependencies (Jersey JE, Guernsey GG, Isle of Man IM) and Gibraltar (GI) use UK-style postcodes but are not in ITL geography or NSPL. They are registered territories (see [Overseas regions and territories](#overseas-regions-and-territories)): a well-formed UK-pattern code returns `200` with a `context` block and `nuts_coverage: "none"`, not an ITL result.
 
 ## Upgrading to 3.0.0
 
@@ -81,6 +81,13 @@ longer emits `400`. `404` now means only that the URL is not a route of this API
 Three response models gain `found` (bool) and `message` (string or null); `PatternResponse.regex`
 and `PatternResponse.example` become nullable. Clients with strict schemas must widen those
 types.
+
+**The `territory` block is renamed to `context`** (`TerritoryInfo` → `ContextInfo`). It covers
+three kinds of place — outermost regions, which are integral parts of a Member State; overseas
+countries and territories, several of them constituent countries; and other European areas such
+as the Crown Dependencies — so naming it for any one of them described the other two wrongly.
+Nothing inside the block changes, `status` included: read `body["context"]` where you read
+`body["territory"]`.
 
 Replace status-code branching with the flag:
 
@@ -112,12 +119,12 @@ nullable. Clients with strict schemas must widen those types before upgrading; c
 read JSON dynamically need only handle `null`.
 
 Eight postal ranges that previously returned a European NUTS region now return `null` with a
-`territory` block: French `975xx`, `977xx`, `978xx`, `984xx`, `986xx`, `987xx`, `988xx`, and
+`context` block: French `975xx`, `977xx`, `978xx`, `984xx`, `986xx`, `987xx`, `988xx`, and
 Danish `39xx`. Those answers were wrong — `FR/98800` in Nouméa resolved to Alpes-Maritimes —
 so the correction may reduce your match rate while improving its accuracy.
 
 The fabricated Faroe Islands codes `FO0`/`FO00`/`FO000` are gone. They were invented by this
-project, not published by Eurostat. `FO` lookups now return a `territory` block with null NUTS.
+project, not published by Eurostat. `FO` lookups now return a `context` block with null NUTS.
 
 ## Deployment tiers
 
@@ -322,15 +329,21 @@ Every response includes:
 
 See [Five-tier lookup](#five-tier-lookup) below for details on match types and confidence values.
 
-#### The `territory` block
+#### The `context` block
 
-Present when the postal code lies in an overseas region or territory; `null` otherwise.
+Present when the postal code lies outside the ordinary NUTS country set; `null` otherwise.
+
+The block is deliberately not named for any one kind of place, because it covers three:
+EU **outermost regions** (integral parts of a Member State — Réunion is a French region),
+**overseas countries and territories** (several of them constituent countries — Aruba,
+Greenland), and **other European areas** such as the Crown Dependencies and Svalbard.
+`status` tells you which.
 
 | Field | Meaning |
 |---|---|
 | `id` | Registry id — the ISO code where one exists, else `ES-CN`, `PT-20`, `PT-30` |
 | `iso` | ISO 3166-1 alpha-2 code, or `null` for the three without one |
-| `name` | Territory name |
+| `name` | Name of the region, country or territory |
 | `status` | `outermost_region`, `oct`, or `other` |
 | `administering_country` | ISO code of the administering country |
 | `legal_basis` | Treaty provision, e.g. `TFEU Art. 349` |
@@ -362,7 +375,7 @@ curl 'https://api.datatoolset.eu/PostalCode2NUTS/lookup?country=NC&postal_code=9
   "nuts1": null, "nuts1_name": null, "nuts1_confidence": null,
   "nuts2": null, "nuts2_name": null, "nuts2_confidence": null,
   "nuts3": null, "nuts3_name": null, "nuts3_confidence": null,
-  "territory": {
+  "context": {
     "id": "NC",
     "iso": "NC",
     "name": "New Caledonia",
@@ -388,7 +401,7 @@ An outermost region resolves as usual and is labelled:
   "nuts1": "FRY", "nuts1_name": "RUP FR — Régions Ultrapériphériques Françaises", "nuts1_confidence": 1.0,
   "nuts2": "FRY4", "nuts2_name": "La Réunion", "nuts2_confidence": 1.0,
   "nuts3": "FRY40", "nuts3_name": "La Réunion", "nuts3_confidence": 1.0,
-  "territory": {
+  "context": {
     "id": "RE", "iso": "RE", "name": "Réunion",
     "status": "outermost_region", "administering_country": "FR",
     "legal_basis": "TFEU Art. 349", "note": null, "nuts_coverage": "full"
@@ -491,7 +504,7 @@ curl -s "localhost:8000/resolve?country=NL&postal_code=1012AB&street=Dam&city=Am
 
 **Response fields:** `found`, `message`, `country_code`, `postal_code`, `resolved_via`
 (`postal` | `geocode` | `none`), `match_type`, `nuts1..nuts3` (+ `_name`),
-`nuts3_confidence`, `territory` (see [The `territory` block](#the-territory-block)), and a
+`nuts3_confidence`, `context` (see [The `context` block](#the-context-block)), and a
 `geocode` object: `status`, `lat`, `lon`, `nuts3`, `snap_km`.
 
 An unserved country is a `200` with `found: false`, `resolved_via: "none"` and
@@ -586,7 +599,7 @@ Country not served by this instance — `GET /lookup?country=XX&postal_code=1234
   "nuts1": null, "nuts1_name": null, "nuts1_confidence": null,
   "nuts2": null, "nuts2_name": null, "nuts2_confidence": null,
   "nuts3": null, "nuts3_name": null, "nuts3_confidence": null,
-  "territory": null
+  "context": null
 }
 ```
 
@@ -621,7 +634,7 @@ construction rather than by absence of data (`FO/100`, `AW`, `GL`):
   "found": true,
   "message": "Faroe Islands is outside the NUTS classification, so no NUTS code exists for this postal code.",
   "postal_code": "100", "country_code": "FO", "nuts3": null,
-  "territory": {"id": "FO", "name": "Faroe Islands", "nuts_coverage": "none", "...": "..."}
+  "context": {"id": "FO", "name": "Faroe Islands", "nuts_coverage": "none", "...": "..."}
 }
 ```
 
@@ -705,7 +718,7 @@ User input: "Traiskirchen"
 | EL | 5 digits or 2+3 / 3+2 with space | GR-, EL- | `10431`, `GR-10431`, `EL-10431`, `105 57` |
 | ES | 5 digits | E- | `28001`, `E-28001` |
 | FI | 5 digits | FI- | `00100`, `FI-00100` |
-| FO | 3 digits (outside NUTS — returns a `territory` block, `nuts_coverage: "none"`) | FO- | `100`, `FO-100`, `FO 100` |
+| FO | 3 digits (outside NUTS — returns a `context` block, `nuts_coverage: "none"`) | FO- | `100`, `FO-100`, `FO 100` |
 | FR | 5 digits | F- | `75001`, `F-75001` |
 | HR | 5 digits | HR- | `10000`, `HR-10000` |
 | HU | 4 digits | H- | `1011`, `H-1011` |

--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -1444,7 +1444,7 @@ def _territory_only_result(t) -> dict:
         "nuts3": None,
         "nuts3_name": None,
         "nuts3_confidence": None,
-        "territory": _territory_payload(t, "none"),
+        "context": _territory_payload(t, "none"),
     }
 
 
@@ -1493,7 +1493,7 @@ def lookup(country_code: str, postal_code: str) -> dict | None:
         result = _lookup_cascade(probe_cc, postal_code)
         if result is None:
             return None
-        result["territory"] = _territory_payload(t, "full")
+        result["context"] = _territory_payload(t, "full")
         return result
 
     # Outside NUTS: tier 1 only. A territory with no postal system
@@ -1508,6 +1508,6 @@ def lookup(country_code: str, postal_code: str) -> dict | None:
         nuts3 = _lookup.get((probe_cc, extracted))
         if nuts3 is not None:
             result = _build_result("exact", nuts3)
-            result["territory"] = _territory_payload(t, "tercet_entry_only")
+            result["context"] = _territory_payload(t, "tercet_entry_only")
             return result
     return _territory_only_result(t)

--- a/app/main.py
+++ b/app/main.py
@@ -334,7 +334,7 @@ def _partial_hit_message(result: dict) -> str | None:
     """Explain a hit that carries no NUTS code (a territory outside NUTS)."""
     if result.get("nuts3") is not None:
         return None
-    terr = result.get("territory")
+    terr = result.get("context")
     if terr is None:
         return None
     return f"{terr['name']} is outside the NUTS classification, so no NUTS code exists for this postal code."
@@ -544,7 +544,7 @@ def resolve_endpoint(
     )
     # /resolve carries PII → do not cache.
     response.headers["Cache-Control"] = "no-store"
-    found = result.get("resolved_via") != "none" or result.get("territory") is not None
+    found = result.get("resolved_via") != "none" or result.get("context") is not None
     return ResolveResponse(
         found=found,
         message=None

--- a/app/models.py
+++ b/app/models.py
@@ -3,8 +3,15 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-class TerritoryInfo(BaseModel):
-    """Identifies an EU outermost region, OCT, or other non-NUTS territory."""
+class ContextInfo(BaseModel):
+    """Context for a postal code that sits outside the ordinary NUTS country set.
+
+    Covers three kinds of place, which is why the block is not named for any one
+    of them: EU outermost regions (integral parts of a Member State, e.g. Réunion),
+    overseas countries and territories (several of them constituent countries, e.g.
+    Aruba, Greenland), and other European areas such as the Crown Dependencies and
+    Svalbard.
+    """
 
     id: str = Field(description="Registry id — the ISO code where one exists, else e.g. 'ES-CN'")
     iso: str | None = Field(default=None, description="ISO 3166-1 alpha-2 code, where one exists")
@@ -74,10 +81,12 @@ class NUTSResult(BaseModel):
     nuts3_confidence: float | None = Field(
         default=None, description="Confidence score for NUTS3 (0.0–1.0)", ge=0.0, le=1.0
     )
-    territory: TerritoryInfo | None = Field(
+    context: ContextInfo | None = Field(
         default=None,
         description=(
-            "Present when the postal code lies in an outermost region, an OCT, or another non-NUTS territory"
+            "Present when the postal code lies in an EU outermost region, an overseas "
+            "country or territory, or another area outside the ordinary NUTS country "
+            "set. Null for an ordinary lookup."
         ),
     )
 
@@ -166,5 +175,5 @@ class ResolveResponse(BaseModel):
     nuts3: str | None = None
     nuts3_name: str | None = None
     nuts3_confidence: float | None = None
-    territory: TerritoryInfo | None = None
+    context: ContextInfo | None = None
     geocode: GeocodeInfo

--- a/app/resolver.py
+++ b/app/resolver.py
@@ -53,12 +53,12 @@ def resolve(
             "nuts3_confidence": current.get("nuts3_confidence"),
         }
 
-    territory = current.get("territory") if current else None
+    ctx = current.get("context") if current else None
     base = {"country_code": country, "postal_code": postal_code, "match_type": match_type}
-    if territory is not None:
-        base["territory"] = territory
-        if territory["nuts_coverage"] == "none":
-            # No NUTS polygon covers the territory, so a coordinate cannot help:
+    if ctx is not None:
+        base["context"] = ctx
+        if ctx["nuts_coverage"] == "none":
+            # No NUTS polygon covers the area, so a coordinate cannot help:
             # PIP would return pip_outside and we would fall back to the postal
             # answer anyway. Skip the geocoder rather than pay for that round trip.
             return {

--- a/docs/overseas_territories.md
+++ b/docs/overseas_territories.md
@@ -17,7 +17,7 @@ answer always matches the territory's real status.
 | **EU law** | Applies in full (with adaptations) | Does not apply |
 | **In NUTS?** | **Yes**, with one exception (Saint-Martin) | **No** |
 | **Count** | 9 | 13 (mapped to 11 ISO 3166-1 codes; all UK OCTs left in 2020) |
-| **This service** | Resolves `exact` from TERCET, `nuts_coverage: "full"` | Returns a `territory` block with null NUTS, `nuts_coverage: "none"` |
+| **This service** | Resolves `exact` from TERCET, `nuts_coverage: "full"` | Returns a `context` block with null NUTS, `nuts_coverage: "none"` |
 
 ## Outermost regions
 
@@ -46,13 +46,13 @@ own — reach them only through `PT` or `ES` postal codes; the registry keys the
 > **Saint-Martin's** single postal code, `97150`, falls inside Guadeloupe's `971xx` block in
 > the raw digits, but the territory registry gates on the code itself, not the prefix, and
 > `97150` is not a row TERCET carries. A lookup for `MF/97150` or `FR/97150` now returns
-> `200` with a `territory` block and null NUTS (`nuts_coverage: "none"`) — not Guadeloupe's
+> `200` with a `context` block and null NUTS (`nuts_coverage: "none"`) — not Guadeloupe's
 > `FRY10`, which is what it returned before this registry existed.
 
 ## Overseas countries and territories
 
 None of the 13 OCTs has a NUTS region, so no lookup can return one. All eleven ISO-coded
-entries return `200` with a `territory` block and `nuts_coverage: "none"` — either on their
+entries return `200` with a `context` block and `nuts_coverage: "none"` — either on their
 own ISO code, or on a well-formed postal code under the administering country that falls in
 the territory's range.
 
@@ -103,14 +103,14 @@ Mayen); the `917xx` block resolves to `NO0B2` (Svalbard) — for example `9170` 
 
 **The Faroe Islands** are an autonomous Danish territory the Treaties do not apply to (Art.
 355(5)(a) TFEU). There is no NUTS coverage and no GISCO TERCET file, so `FO` lookups return a
-`territory` block with null NUTS and `nuts_coverage: "none"`. Earlier releases of this service
+`context` block with null NUTS and `nuts_coverage: "none"`. Earlier releases of this service
 fabricated `FO0` / `FO00` / `FO000` as a synthetic single-region result — that code was
 invented by this project, never published by Eurostat, and has been removed. Contrast
 Montenegro's `ME000`, which is a genuine Eurostat single-region NUTS code.
 
 **Gibraltar and the three Crown Dependencies** use UK-style postcodes but sit outside ITL
 geography and the NSPL, so they cannot resolve even when UK/ITL coverage is configured. A
-well-formed UK-pattern code under `GI`, `JE`, `GG` or `IM` returns `200` with a `territory`
+well-formed UK-pattern code under `GI`, `JE`, `GG` or `IM` returns `200` with a `context`
 block and null NUTS.
 
 ## Implemented behaviour

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,7 @@ class TestLookupEndpoint:
         assert body["country_code"] == "ZZ"
         assert body["postal_code"] == "12345"
         assert body["nuts3"] is None
-        assert body["territory"] is None
+        assert body["context"] is None
 
     def test_no_match_is_200_not_found(self, client):
         """EL has data but this postal code has no match (only 11141 in mock)."""
@@ -170,9 +170,9 @@ class TestFaroeIslandsAPI:
         assert body["nuts1"] is None
         assert body["nuts3_confidence"] is None
         assert body["nuts1_name"] is None
-        assert body["territory"]["id"] == "FO"
-        assert body["territory"]["name"] == "Faroe Islands"
-        assert body["territory"]["nuts_coverage"] == "none"
+        assert body["context"]["id"] == "FO"
+        assert body["context"]["name"] == "Faroe Islands"
+        assert body["context"]["nuts_coverage"] == "none"
         # A recognised code is a hit even where no NUTS code exists — found
         # stays true and message explains the null NUTS fields.
         assert body["found"] is True
@@ -183,7 +183,7 @@ class TestFaroeIslandsAPI:
         assert r.status_code == 200
         body = r.json()
         assert body["nuts3"] is None
-        assert body["territory"]["id"] == "FO"
+        assert body["context"]["id"] == "FO"
 
     def test_lookup_fo_bad_format_is_200_not_found(self, client):
         r = client.get("/lookup", params={"country": "FO", "postal_code": "1234"})

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -155,19 +155,19 @@ class TestLookup:
         assert result["nuts3"] is None
         assert result["nuts2"] is None
         assert result["nuts1"] is None
-        assert result["territory"]["id"] == "FO"
-        assert result["territory"]["nuts_coverage"] == "none"
+        assert result["context"]["id"] == "FO"
+        assert result["context"]["nuts_coverage"] == "none"
 
     def test_fo_territory_names(self, mock_data):
         result = lookup("FO", "100")
         assert result["nuts1_name"] is None
         assert result["nuts2_name"] is None
         assert result["nuts3_name"] is None
-        assert result["territory"]["name"] == "Faroe Islands"
+        assert result["context"]["name"] == "Faroe Islands"
 
     def test_fo_prefix_variants(self, mock_data):
         for raw in ("FO-100", "FO 100", "FO100", "970", "999"):
-            assert lookup("FO", raw)["territory"]["id"] == "FO"
+            assert lookup("FO", raw)["context"]["id"] == "FO"
 
     def test_fo_rejects_bad_format(self, mock_data):
         """Format guard: non-3-digit input is rejected outright by the gate."""

--- a/tests/test_models_territory.py
+++ b/tests/test_models_territory.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from app.models import NUTSResult, TerritoryInfo
+from app.models import NUTSResult, ContextInfo
 
 
 def test_territory_only_result_validates_with_null_nuts():
@@ -14,7 +14,7 @@ def test_territory_only_result_validates_with_null_nuts():
         nuts1=None, nuts1_confidence=None,
         nuts2=None, nuts2_confidence=None,
         nuts3=None, nuts3_confidence=None,
-        territory=TerritoryInfo(
+        context=ContextInfo(
             id="NC", iso="NC", name="New Caledonia", status="oct",
             administering_country="FR", legal_basis="TFEU Part Four, Annex II",
             note=None, nuts_coverage="none",
@@ -22,8 +22,8 @@ def test_territory_only_result_validates_with_null_nuts():
     )
     assert r.nuts3 is None
     assert r.match_type is None
-    assert r.territory.status == "oct"
-    assert r.territory.nuts_coverage == "none"
+    assert r.context.status == "oct"
+    assert r.context.nuts_coverage == "none"
 
 
 def test_ordinary_result_omits_the_territory_block():
@@ -33,12 +33,12 @@ def test_ordinary_result_omits_the_territory_block():
         nuts2="DE30", nuts2_confidence=1.0,
         nuts3="DE300", nuts3_confidence=1.0,
     )
-    assert r.territory is None
+    assert r.context is None
 
 
 def test_nuts_coverage_is_constrained():
     with pytest.raises(ValidationError):
-        TerritoryInfo(
+        ContextInfo(
             id="NC", iso="NC", name="New Caledonia", status="oct",
             administering_country="FR", legal_basis=None, note=None,
             nuts_coverage="partial",
@@ -47,7 +47,7 @@ def test_nuts_coverage_is_constrained():
 
 def test_status_is_constrained():
     with pytest.raises(ValidationError):
-        TerritoryInfo(
+        ContextInfo(
             id="NC", iso="NC", name="New Caledonia", status="colony",
             administering_country="FR", legal_basis=None, note=None,
             nuts_coverage="none",

--- a/tests/test_not_found_contract.py
+++ b/tests/test_not_found_contract.py
@@ -36,7 +36,7 @@ class TestLookupNotFound:
             "nuts3",
             "nuts3_name",
             "nuts3_confidence",
-            "territory",
+            "context",
         ):
             assert body[field] is None, field
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -189,7 +189,7 @@ def test_resolve_skips_the_geocoder_for_a_territory_with_no_coverage():
         lookup_fn=lambda c, p: {
             "match_type": None, "nuts1": None, "nuts2": None, "nuts3": None,
             "nuts1_name": None, "nuts2_name": None, "nuts3_name": None,
-            "nuts3_confidence": None, "territory": territory,
+            "nuts3_confidence": None, "context": territory,
         },
         geocode_fn=geocode_fn,
         pip=None,
@@ -199,7 +199,7 @@ def test_resolve_skips_the_geocoder_for_a_territory_with_no_coverage():
     assert result["geocode"]["status"] == "not_attempted"
     assert result["resolved_via"] == "none"
     assert result["nuts3"] is None
-    assert result["territory"]["id"] == "NC"
+    assert result["context"]["id"] == "NC"
 
 
 def test_resolve_still_geocodes_a_weak_ordinary_result():

--- a/tests/test_territory_api.py
+++ b/tests/test_territory_api.py
@@ -9,10 +9,10 @@ def test_oct_returns_200_with_a_territory_block(client):
     r = client.get("/lookup", params={"country": "NC", "postal_code": "98800"})
     assert r.status_code == 200
     body = r.json()
-    assert body["territory"]["name"] == "New Caledonia"
-    assert body["territory"]["status"] == "oct"
-    assert body["territory"]["nuts_coverage"] == "none"
-    assert body["territory"]["legal_basis"] == "TFEU Part Four, Annex II"
+    assert body["context"]["name"] == "New Caledonia"
+    assert body["context"]["status"] == "oct"
+    assert body["context"]["nuts_coverage"] == "none"
+    assert body["context"]["legal_basis"] == "TFEU Part Four, Annex II"
     assert body["nuts3"] is None
     assert body["match_type"] is None
 
@@ -49,8 +49,8 @@ def test_territory_without_a_postal_system_answers_on_the_country_code(client):
     r = client.get("/lookup", params={"country": "AW", "postal_code": ""})
     assert r.status_code == 200
     body = r.json()
-    assert body["territory"]["name"] == "Aruba"
-    assert "no postal codes" in body["territory"]["note"]
+    assert body["context"]["name"] == "Aruba"
+    assert "no postal codes" in body["context"]["note"]
 
 
 def test_outermost_region_keeps_its_nuts_codes(client, mock_data):
@@ -58,13 +58,13 @@ def test_outermost_region_keeps_its_nuts_codes(client, mock_data):
     data_loader._build_prefix_index()
     body = client.get("/lookup", params={"country": "RE", "postal_code": "97400"}).json()
     assert body["nuts3"] == "FRY40"
-    assert body["territory"]["status"] == "outermost_region"
-    assert body["territory"]["nuts_coverage"] == "full"
+    assert body["context"]["status"] == "outermost_region"
+    assert body["context"]["nuts_coverage"] == "full"
 
 
 def test_ordinary_lookup_has_a_null_territory(client):
     body = client.get("/lookup", params={"country": "DE", "postal_code": "10115"}).json()
-    assert body["territory"] is None
+    assert body["context"] is None
     assert body["nuts3"] == "DE300"
 
 
@@ -103,3 +103,32 @@ def test_pattern_not_found_for_a_territory_with_no_postal_system(client):
 
 def test_health_reports_the_registry_size(client):
     assert client.get("/health").json()["territories"] == 26
+
+
+def test_the_block_is_named_context_not_territory(client):
+    """The block covers regions, countries and dependencies alike, so it is not
+    named for any one of them. The old key must be gone, not merely aliased."""
+    body = client.get("/lookup", params={"country": "NC", "postal_code": "98800"}).json()
+    assert "territory" not in body
+    assert body["context"]["name"] == "New Caledonia"
+
+
+def test_context_is_null_for_an_ordinary_lookup(client):
+    body = client.get("/lookup", params={"country": "DE", "postal_code": "10115"}).json()
+    assert "territory" not in body
+    assert body["context"] is None
+
+
+def test_openapi_exposes_context_not_territory():
+    from unittest.mock import patch
+
+    from app import data_loader
+
+    with patch.object(data_loader, "load_data"):
+        from app.main import app
+
+        schema = app.openapi()
+    props = schema["components"]["schemas"]["NUTSResult"]["properties"]
+    assert "context" in props and "territory" not in props
+    assert "ContextInfo" in schema["components"]["schemas"]
+    assert "TerritoryInfo" not in schema["components"]["schemas"]

--- a/tests/test_territory_lookup.py
+++ b/tests/test_territory_lookup.py
@@ -18,9 +18,9 @@ def test_outermost_region_resolves_and_is_labelled(mock_data):
     r = data_loader.lookup("FR", "97400")
     assert r["match_type"] == "exact"
     assert r["nuts3"] == "FRY40"
-    assert r["territory"]["id"] == "RE"
-    assert r["territory"]["status"] == "outermost_region"
-    assert r["territory"]["nuts_coverage"] == "full"
+    assert r["context"]["id"] == "RE"
+    assert r["context"]["status"] == "outermost_region"
+    assert r["context"]["nuts_coverage"] == "full"
 
 
 def test_iso_route_matches_the_parent_route(mock_data):
@@ -35,9 +35,9 @@ def test_iso_route_matches_the_parent_route(mock_data):
 
 def test_oct_returns_a_territory_only_result(mock_data):
     r = data_loader.lookup("FR", "98800")
-    assert r["territory"]["id"] == "NC"
-    assert r["territory"]["status"] == "oct"
-    assert r["territory"]["nuts_coverage"] == "none"
+    assert r["context"]["id"] == "NC"
+    assert r["context"]["status"] == "oct"
+    assert r["context"]["nuts_coverage"] == "none"
     assert r["match_type"] is None
     for field in ("nuts1", "nuts2", "nuts3", "nuts1_name", "nuts2_name", "nuts3_name",
                   "nuts1_confidence", "nuts2_confidence", "nuts3_confidence"):
@@ -53,14 +53,14 @@ def test_oct_never_reaches_the_monaco_prefix_chain(mock_data):
     # Monaco itself is untouched and carries no territory block.
     monaco = data_loader.lookup("FR", "98000")
     assert monaco["nuts3"] == "FRL03"
-    assert monaco.get("territory") is None
+    assert monaco.get("context") is None
 
 
 def test_greenland_never_reaches_the_danish_prefix_fallback(mock_data):
     data_loader._lookup[("DK", "3700")] = "DK014"
     data_loader._build_prefix_index()
     r = data_loader.lookup("DK", "3900")
-    assert r["territory"]["id"] == "GL"
+    assert r["context"]["id"] == "GL"
     assert r["nuts3"] is None
 
 
@@ -68,9 +68,9 @@ def test_saint_martin_loses_its_approximation(mock_data):
     data_loader._lookup[("FR", "97100")] = "FRY10"
     data_loader._build_prefix_index()
     r = data_loader.lookup("FR", "97150")
-    assert r["territory"]["id"] == "MF"
-    assert r["territory"]["status"] == "outermost_region"
-    assert r["territory"]["nuts_coverage"] == "none"
+    assert r["context"]["id"] == "MF"
+    assert r["context"]["status"] == "outermost_region"
+    assert r["context"]["nuts_coverage"] == "none"
     assert r["nuts3"] is None
 
 
@@ -78,8 +78,8 @@ def test_tercet_entry_only_keeps_a_genuine_eurostat_row(mock_data):
     data_loader._lookup[("FR", "97133")] = "FRY10"
     data_loader._build_prefix_index()
     r = data_loader.lookup("FR", "97133")
-    assert r["territory"]["id"] == "BL"
-    assert r["territory"]["nuts_coverage"] == "tercet_entry_only"
+    assert r["context"]["id"] == "BL"
+    assert r["context"]["nuts_coverage"] == "tercet_entry_only"
     assert r["match_type"] == "exact"
     assert r["nuts3"] == "FRY10"
     assert r["nuts3_confidence"] == 1.0
@@ -87,8 +87,8 @@ def test_tercet_entry_only_keeps_a_genuine_eurostat_row(mock_data):
 
 def test_sibling_code_without_a_tercet_row_returns_none_coverage(mock_data):
     r = data_loader.lookup("FR", "97705")
-    assert r["territory"]["id"] == "BL"
-    assert r["territory"]["nuts_coverage"] == "none"
+    assert r["context"]["id"] == "BL"
+    assert r["context"]["nuts_coverage"] == "none"
     assert r["nuts3"] is None
 
 
@@ -114,18 +114,18 @@ def test_svalbard_is_in_nuts(mock_data):
     data_loader._build_prefix_index()
     r = data_loader.lookup("SJ", "9170")
     assert r["nuts3"] == "NO0B2"
-    assert r["territory"]["nuts_coverage"] == "full"
-    assert r["territory"]["status"] == "other"
+    assert r["context"]["nuts_coverage"] == "full"
+    assert r["context"]["status"] == "other"
 
 
 # ── Territories with no postal system ────────────────────────────────────────
 
 def test_aruba_answers_on_the_country_code_alone(mock_data):
     r = data_loader.lookup("AW", "")
-    assert r["territory"]["id"] == "AW"
-    assert r["territory"]["nuts_coverage"] == "none"
+    assert r["context"]["id"] == "AW"
+    assert r["context"]["nuts_coverage"] == "none"
     assert r["nuts3"] is None
-    assert data_loader.lookup("AW", "anything")["territory"]["id"] == "AW"
+    assert data_loader.lookup("AW", "anything")["context"]["id"] == "AW"
 
 
 def test_dutch_octs_never_reach_the_netherlands_rows(mock_data):
@@ -135,8 +135,8 @@ def test_dutch_octs_never_reach_the_netherlands_rows(mock_data):
     data_loader._build_prefix_index()
     for iso in ("AW", "CW", "SX", "BQ"):
         r = data_loader.lookup(iso, "1012")
-        assert r["territory"]["id"] == iso
-        assert r["territory"]["nuts_coverage"] == "none"
+        assert r["context"]["id"] == iso
+        assert r["context"]["nuts_coverage"] == "none"
         assert r["nuts3"] is None
         assert r["match_type"] is None
 
@@ -148,14 +148,14 @@ def test_crown_dependency_codes_reach_the_territory_statement(mock_data):
     # come back as a territory rather than a 404.
     r = data_loader.lookup("JE", "JE2 3XP")
     assert r is not None, "UK pattern rejected a Jersey code"
-    assert r["territory"]["id"] == "JE"
-    assert r["territory"]["nuts_coverage"] == "none"
+    assert r["context"]["id"] == "JE"
+    assert r["context"]["nuts_coverage"] == "none"
 
 
 def test_faroe_islands_no_longer_return_a_fabricated_code(mock_data):
     r = data_loader.lookup("FO", "100")
-    assert r["territory"]["id"] == "FO"
-    assert r["territory"]["nuts_coverage"] == "none"
+    assert r["context"]["id"] == "FO"
+    assert r["context"]["nuts_coverage"] == "none"
     assert r["nuts3"] is None
 
 
@@ -170,14 +170,14 @@ def test_ordinary_lookups_are_unchanged(mock_data):
     r = data_loader.lookup("DE", "10115")
     assert r["nuts3"] == "DE300"
     assert r["match_type"] == "exact"
-    assert r.get("territory") is None
+    assert r.get("context") is None
 
 
 def test_montenegro_single_nuts3_fallback_survives(mock_data):
     data_loader._single_nuts3["ME"] = "ME000"
     r = data_loader.lookup("ME", "81000")
     assert r["nuts3"] == "ME000"
-    assert r.get("territory") is None
+    assert r.get("context") is None
 
 
 def test_territory_iso_codes_are_supported_countries():


### PR DESCRIPTION
> Stacked on #164 — review that first. The base will retarget to `main` automatically when #164 merges.

## Why

The block is returned for three different kinds of place, and "territory" is only correct for one of them:

| Category | Examples | Is it a "territory"? |
|---|---|---|
| `outermost_region` | Réunion, Guadeloupe, Madeira, Canarias | **No** — integral parts of a Member State. Réunion is a French *region* and a NUTS-2 unit |
| `oct` | Aruba, Curaçao, Greenland, New Caledonia | Partly — several are constituent *countries* of the Kingdom of the Netherlands or of Denmark |
| `other` | Jersey, Guernsey, Isle of Man, Faroes, Gibraltar, Svalbard | Partly — Crown Dependencies are not territories of the UK |

`context` is neutral across all three and stays correct whichever category the answer falls in.

## What changes

```diff
 {
   "postal_code": "98800",
   "country_code": "NC",
   "nuts3": null,
-  "territory": {
+  "context": {
     "id": "NC",
     "name": "New Caledonia",
     "status": "oct",
     "administering_country": "FR",
     "legal_basis": "TFEU Part Four, Annex II",
     "nuts_coverage": "none"
   }
 }
```

- `NUTSResult.territory` → `NUTSResult.context`, same on `ResolveResponse`
- `TerritoryInfo` → `ContextInfo`, with a docstring stating why the block is not named for a place-kind
- **Nothing inside the block moves** — `id`, `iso`, `name`, `status`, `administering_country`, `legal_basis`, `note`, `nuts_coverage` are all unchanged. `status` in particular stays `status`; it does not stutter after `context.`
- Docs: the README section is now **The `context` block** and explains the three categories up front; `docs/overseas_territories.md` and the scattered references follow

## What deliberately does not change

The internal registry keeps its names — `app/territories.py`, `app/territories.json`, the `Territory` and `Classification` dataclasses, `classify()`, `docs/overseas_territories.md`. That layer really is a registry of territories in the EU-law sense, and renaming it would add ~15 files of mechanical churn to a public-surface fix.

## Tests

`470 passed`. Three new tests in `test_territory_api.py` pin the rename rather than just following it: the old key must be **absent** from the body (not aliased), `context` must be `null` for an ordinary lookup, and the generated OpenAPI must expose `ContextInfo` with no `TerritoryInfo` left behind. Existing assertions across six test modules were updated. `ruff check` clean.