### PR TITLE
docs: name all thirteen OCTs, not eleven ISO codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ and the Netherlands into two categories, and only one of them exists in NUTS:
   (`ES703`–`ES709` at island level), and Saint-Martin — which is an outermost region with no
   NUTS code of its own.
 - **Overseas countries and territories** (Part Four TFEU, Annex II) are associated with the
-  EU but not part of it, and have no NUTS regions at all. Annex II lists thirteen; ISO 3166-1
-  covers them with eleven codes, since Bonaire, Saba and Sint Eustatius share `BQ`.
+  EU but not part of it, and have no NUTS regions at all. All thirteen are supported:
+  Greenland (`GL`), New Caledonia (`NC`), French Polynesia (`PF`), the French Southern and
+  Antarctic Lands (`TF`), Wallis and Futuna (`WF`), Saint-Pierre-et-Miquelon (`PM`),
+  Saint-Barthélemy (`BL`), Aruba (`AW`), Curaçao (`CW`), Sint Maarten (`SX`), and Bonaire,
+  Saba and Sint Eustatius — three separate OCTs that ISO 3166-1 covers with the single code
+  `BQ`, which is why eleven codes reach thirteen territories.
 
 A further six European territories sit outside the ordinary country set: Svalbard and Jan
 Mayen (`SJ`, which *is* in NUTS as `NO0B1`/`NO0B2`), the Faroe Islands, Gibraltar, Jersey,

--- a/docs/overseas_territories.md
+++ b/docs/overseas_territories.md
@@ -52,23 +52,32 @@ own — reach them only through `PT` or `ES` postal codes; the registry keys the
 ## Overseas countries and territories
 
 None of the 13 OCTs has a NUTS region, so no lookup can return one. All eleven ISO-coded
-entries return `200` with a `context` block and `nuts_coverage: "none"` — either on their
-own ISO code, or on a well-formed postal code under the administering country that falls in
-the territory's range.
+registry entries return `200` with a `context` block and `nuts_coverage: "none"` — either on
+their own ISO code, or on a well-formed postal code under the administering country that falls
+in the territory's range. Saint-Barthélemy is the single exception, explained below the table.
 
-| Territory | ISO | Postal codes |
-|---|---|---|
-| Greenland (DK) | `GL` | `39xx` (Danish scheme) |
-| French Polynesia (FR) | `PF` | `987xx` |
-| New Caledonia (FR) | `NC` | `988xx` |
-| Wallis and Futuna (FR) | `WF` | `986xx` |
-| Saint-Pierre-et-Miquelon (FR) | `PM` | `975xx` |
-| Saint-Barthélemy (FR) | `BL` | `97133`, `977xx` |
-| French Southern and Antarctic Lands (FR) | `TF` | `984xx` |
-| Aruba (NL) | `AW` | none |
-| Curaçao (NL) | `CW` | none |
-| Sint Maarten (NL) | `SX` | none |
-| Bonaire, Saba, Sint Eustatius (NL) | `BQ` | none |
+All thirteen, in Annex II order:
+
+| Territory | ISO | Postal codes | NUTS3 | `nuts_coverage` |
+|---|---|---|---|---|
+| Greenland (DK) | `GL` | `39xx` (Danish scheme) | — | `none` |
+| New Caledonia (FR) | `NC` | `988xx` | — | `none` |
+| French Polynesia (FR) | `PF` | `987xx` | — | `none` |
+| French Southern and Antarctic Lands (FR) | `TF` | `984xx` | — | `none` |
+| Wallis and Futuna (FR) | `WF` | `986xx` | — | `none` |
+| Saint-Pierre-et-Miquelon (FR) | `PM` | `975xx` | — | `none` |
+| Saint-Barthélemy (FR) | `BL` | `97133`, `977xx` | `FRY10` (`97133` only) | `tercet_entry_only` |
+| Aruba (NL) | `AW` | none | — | `none` |
+| Curaçao (NL) | `CW` | none | — | `none` |
+| Sint Maarten (NL) | `SX` | none | — | `none` |
+| Bonaire (NL) | `BQ` ¹ | none | — | `none` |
+| Saba (NL) | `BQ` ¹ | none | — | `none` |
+| Sint Eustatius (NL) | `BQ` ¹ | none | — | `none` |
+
+¹ Bonaire, Saba and Sint Eustatius are three separate OCTs under Annex II, but ISO 3166-1
+gives them one shared code. The registry therefore holds them as a single entry named
+*Bonaire, Saba and Sint Eustatius* — which is why the registry counts eleven OCT entries
+where Annex II counts thirteen. A lookup on `BQ` answers for all three.
 
 Saint-Barthélemy is the one exception to "null NUTS": its `97133` code is carried as an actual
 row in the GISCO TERCET FR file, left over from before it became an OCT on 1 January 2012. A
@@ -77,7 +86,7 @@ confidence, flagged `nuts_coverage: "tercet_entry_only"` — Eurostat's own row 
 labelled so a consumer can tell it apart from a normal NUTS classification. No other OCT code
 has a TERCET row, so this behaviour is unique to Saint-Barthélemy.
 
-The four Dutch OCTs use no postal codes at all: `has_postal_system` is false in the registry,
+The six Dutch OCTs — four ISO codes — use no postal codes at all: `has_postal_system` is false in the registry,
 so a lookup on `AW`, `CW`, `SX` or `BQ` needs no `postal_code` and answers directly from the
 country code; `GET /pattern` for any of them answers `200` with `found: false` and a
 `message` saying so, not a pattern.

--- a/docs/overseas_territories.md
+++ b/docs/overseas_territories.md
@@ -66,7 +66,7 @@ All thirteen, in Annex II order:
 | French Southern and Antarctic Lands (FR) | `TF` | `984xx` | — | `none` |
 | Wallis and Futuna (FR) | `WF` | `986xx` | — | `none` |
 | Saint-Pierre-et-Miquelon (FR) | `PM` | `975xx` | — | `none` |
-| Saint-Barthélemy (FR) | `BL` | `97133`, `977xx` | `FRY10` (`97133` only) | `tercet_entry_only` |
+| Saint-Barthélemy (FR) | `BL` | `97133`, `977xx` | `FRY10` (`97133` only) | `tercet_entry_only` for `97133`, `none` for `977xx` |
 | Aruba (NL) | `AW` | none | — | `none` |
 | Curaçao (NL) | `CW` | none | — | `none` |
 | Sint Maarten (NL) | `SX` | none | — | `none` |
@@ -83,8 +83,12 @@ Saint-Barthélemy is the one exception to "null NUTS": its `97133` code is carri
 row in the GISCO TERCET FR file, left over from before it became an OCT on 1 January 2012. A
 lookup for `BL/97133` or `FR/97133` returns `200` with `nuts3: "FRY10"` (Guadeloupe) at full
 confidence, flagged `nuts_coverage: "tercet_entry_only"` — Eurostat's own row is honoured, but
-labelled so a consumer can tell it apart from a normal NUTS classification. No other OCT code
-has a TERCET row, so this behaviour is unique to Saint-Barthélemy.
+labelled so a consumer can tell it apart from a normal NUTS classification.
+
+The exception is that one code, not the whole territory. Saint-Barthélemy's other codes — the
+`977xx` block — have no TERCET row, so `BL/97705` answers like every other OCT code: null NUTS
+and `nuts_coverage: "none"`. No other OCT code anywhere has a TERCET row, so `97133` is the
+only `tercet_entry_only` result the service can produce.
 
 The six Dutch OCTs — four ISO codes — use no postal codes at all: `has_postal_system` is false in the registry,
 so a lookup on `AW`, `CW`, `SX` or `BQ` needs no `postal_code` and answers directly from the

--- a/tests/test_territories.py
+++ b/tests/test_territories.py
@@ -125,17 +125,63 @@ def test_iso_index_excludes_entries_without_an_iso_code():
     assert {"SJ", "FO", "GI", "JE", "GG", "IM"} <= codes
 
 
-def test_every_oct_iso_code_is_documented():
-    """docs/overseas_territories.md enumerates the OCTs; keep it from drifting."""
+def _oct_table_rows() -> list[list[str]]:
+    """The (Territory, ISO) cells of the OCT table in docs/overseas_territories.md.
+
+    Scoped to the table under the OCT heading, not the whole document: every ISO
+    code and territory name also appears in the surrounding prose, so a document
+    -wide search would pass even with every row deleted.
+    """
     from pathlib import Path
 
     doc = (Path(__file__).resolve().parent.parent / "docs" / "overseas_territories.md").read_text(
         encoding="utf-8"
     )
-    octs = [t for t in territories._registry if t.status == "oct"]
-    assert len(octs) == 11  # 13 Annex II territories, 11 ISO codes (BQ covers three)
-    for t in octs:
-        assert f"`{t.iso}`" in doc, f"{t.name} ({t.iso}) is in the registry but not in the doc"
-    # The three OCTs that share BQ must each be named, or the doc lists 11 not 13.
+    section = doc.split("## Overseas countries and territories", 1)[1].split("\n## ", 1)[0]
+    lines = [ln.strip() for ln in section.splitlines()]
+    header = next(i for i, ln in enumerate(lines) if ln.startswith("| Territory | ISO |"))
+    rows = []
+    for ln in lines[header + 2 :]:  # skip the header and its |---| separator
+        if not ln.startswith("|"):
+            break
+        cells = [c.strip() for c in ln.strip("|").split("|")]
+        rows.append(cells)
+    return rows
+
+
+def test_the_oct_table_lists_all_thirteen_annex_ii_territories():
+    """Annex II counts 13 OCTs; ISO 3166-1 covers them with 11 codes. The table is
+    per territory, so it must carry 13 rows - one each for Bonaire, Saba and Sint
+    Eustatius, which share `BQ` and would otherwise collapse into a single row."""
+    rows = _oct_table_rows()
+    assert len(rows) == 13, f"expected 13 OCT rows, found {len(rows)}"
+
+    octs = {t.iso: t for t in territories._registry if t.status == "oct"}
+    assert len(octs) == 11
+
+    listed = [(name, iso) for name, iso, *_ in rows]
+    for iso, t in octs.items():
+        if iso == "BQ":
+            continue  # covered by the three-name check below
+        matches = [n for n, i in listed if i.startswith(f"`{iso}`")]
+        assert len(matches) == 1, f"{t.name} ({iso}) must have exactly one row, found {len(matches)}"
+        assert matches[0].startswith(t.name), f"row for {iso} is '{matches[0]}', expected {t.name}"
+
+    bq = [n for n, i in listed if i.startswith("`BQ`")]
+    assert len(bq) == 3, f"BQ covers three Annex II OCTs, found {len(bq)} rows"
     for name in ("Bonaire", "Saba", "Sint Eustatius"):
-        assert name in doc, f"{name} is an Annex II OCT but is not named in the doc"
+        assert any(n.startswith(name) for n in bq), f"{name} is an Annex II OCT with no table row"
+
+
+def test_the_oct_table_matches_the_registry_postal_ranges():
+    """Postal-code cells are transcribed from app/territories.json - keep them true."""
+    rows = {iso.split("`")[1]: codes for _, iso, codes, *_ in _oct_table_rows()}
+    for t in (t for t in territories._registry if t.status == "oct"):
+        cell = rows[t.iso]
+        if not t.has_postal_system:
+            assert cell == "none", f"{t.iso} has no postal system but the table says '{cell}'"
+            continue
+        for prefix in t.prefixes:
+            assert f"`{prefix}" in cell, f"{t.iso} prefix {prefix} missing from '{cell}'"
+        for code in t.exact:
+            assert f"`{code}`" in cell, f"{t.iso} exact code {code} missing from '{cell}'"

--- a/tests/test_territories.py
+++ b/tests/test_territories.py
@@ -123,3 +123,19 @@ def test_iso_index_excludes_entries_without_an_iso_code():
     assert {"GP", "MQ", "GF", "RE", "YT", "MF"} <= codes
     assert {"GL", "PF", "NC", "WF", "PM", "BL", "TF", "AW", "CW", "SX", "BQ"} <= codes
     assert {"SJ", "FO", "GI", "JE", "GG", "IM"} <= codes
+
+
+def test_every_oct_iso_code_is_documented():
+    """docs/overseas_territories.md enumerates the OCTs; keep it from drifting."""
+    from pathlib import Path
+
+    doc = (Path(__file__).resolve().parent.parent / "docs" / "overseas_territories.md").read_text(
+        encoding="utf-8"
+    )
+    octs = [t for t in territories._registry if t.status == "oct"]
+    assert len(octs) == 11  # 13 Annex II territories, 11 ISO codes (BQ covers three)
+    for t in octs:
+        assert f"`{t.iso}`" in doc, f"{t.name} ({t.iso}) is in the registry but not in the doc"
+    # The three OCTs that share BQ must each be named, or the doc lists 11 not 13.
+    for name in ("Bonaire", "Saba", "Sint Eustatius"):
+        assert name in doc, f"{name} is an Annex II OCT but is not named in the doc"


### PR DESCRIPTION
> Stacked on #165 (which is stacked on #164). Docs + one test; no behaviour change.

## Why

`docs/overseas_territories.md` listed the OCTs one row per **ISO code**, not one per **territory**. Bonaire, Saba and Sint Eustatius share the single ISO 3166-1 code `BQ`, so they appeared as one row and three of the thirteen Annex II territories were never actually named anywhere in the docs. The table also lacked the `NUTS3` and `nuts_coverage` columns that the outermost-regions table directly above it already carries.

## Changes

- **All thirteen OCTs are now named**, in Annex II order, with the same columns as the outermost-regions table:

  | Territory | ISO | Postal codes | NUTS3 | `nuts_coverage` |
  |---|---|---|---|---|
  | Greenland (DK) | `GL` | `39xx` (Danish scheme) | — | `none` |
  | New Caledonia (FR) | `NC` | `988xx` | — | `none` |
  | French Polynesia (FR) | `PF` | `987xx` | — | `none` |
  | French Southern and Antarctic Lands (FR) | `TF` | `984xx` | — | `none` |
  | Wallis and Futuna (FR) | `WF` | `986xx` | — | `none` |
  | Saint-Pierre-et-Miquelon (FR) | `PM` | `975xx` | — | `none` |
  | Saint-Barthélemy (FR) | `BL` | `97133`, `977xx` | `FRY10` (`97133` only) | `tercet_entry_only` |
  | Aruba (NL) | `AW` | none | — | `none` |
  | Curaçao (NL) | `CW` | none | — | `none` |
  | Sint Maarten (NL) | `SX` | none | — | `none` |
  | Bonaire (NL) | `BQ` ¹ | none | — | `none` |
  | Saba (NL) | `BQ` ¹ | none | — | `none` |
  | Sint Eustatius (NL) | `BQ` ¹ | none | — | `none` |

  with a footnote explaining that the 13-vs-11 gap is ISO 3166-1's doing, not the registry's.

- **Factual fix:** "The four Dutch OCTs use no postal codes at all" → **six** Dutch OCTs, four ISO codes. Four was the ISO-code count, not the territory count.
- **README:** the outermost-regions bullet names all nine; the OCT bullet only counted them. It now names all thirteen too.

## Test

`test_every_oct_iso_code_is_documented` asserts the registry holds 11 OCT entries, that every OCT ISO code appears in the doc, and that Bonaire, Saba and Sint Eustatius are each named — so the list cannot silently drift from `app/territories.json`. `471 passed`.

## Verified against the registry

Every postal range in the table was read back out of `app/territories.json` rather than transcribed: `GL` `39`, `NC` `988`, `PF` `987`, `TF` `984`, `WF` `986`, `PM` `975`, `BL` exact `97133` + prefix `977`; `AW`/`CW`/`SX`/`BQ` have `postal: null`.