### PR TITLE
fix(security): cap the TERCET listing fetch and the geocoder response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   through pydantic, whose `ValidationError` rendering includes the settings input
   dict — printing `PC2NUTS_TRUSTED_TOKENS` and `PC2NUTS_TOKEN_DB_AUTH_TOKEN`
   verbatim into container logs on an unrelated misconfiguration.
+- The TERCET directory listing (`_discover_zip_urls`) and the Photon geocoder
+  response are capped too. The listing is fetched first on a cold cache, before
+  any of the capped ZIP downloads; the geocoder body is buffered on every
+  `/resolve` request.
 - Every remote body the worker buffers is now capped: `PC2NUTS_MAX_DOWNLOAD_MB`
   (default 512) for TERCET/NSPL zips, NUTS polygons and the names CSV,
   `PC2NUTS_MAX_ESTIMATES_DOWNLOAD_MB` (default 64) for the estimates refresh URL.

--- a/app/data_loader.py
+++ b/app/data_loader.py
@@ -227,7 +227,10 @@ def _discover_zip_urls(client: httpx.Client, base_url: str) -> list[str]:
     """Try to discover ZIP file URLs from the TERCET directory listing."""
     urls: list[str] = []
     try:
-        resp = client.get(base_url, timeout=30)
+        # Capped like every other fetch: this one runs first on a cold cache, so
+        # an unbounded listing here would exhaust the worker before any of the
+        # capped ZIP downloads got a chance to.
+        resp = _get_capped(client, base_url, limit_bytes=_max_download_bytes(), timeout=30)
         resp.raise_for_status()
         # Parse href attributes pointing to .zip files
         for match in re.finditer(r'href="([^"]*\.zip)"', resp.text):
@@ -236,8 +239,8 @@ def _discover_zip_urls(client: httpx.Client, base_url: str) -> list[str]:
                 urls.append(href)
             else:
                 urls.append(base_url.rstrip("/") + "/" + href.lstrip("/"))
-    except (httpx.RequestError, httpx.HTTPStatusError):
-        logger.debug("Could not fetch directory listing from %s", base_url)
+    except (httpx.RequestError, httpx.HTTPStatusError, DownloadTooLarge) as exc:
+        logger.debug("Could not fetch directory listing from %s: %s", base_url, exc)
     return urls
 
 

--- a/app/photon_client.py
+++ b/app/photon_client.py
@@ -16,7 +16,15 @@ the correct NUTS-3 region.
 
 from __future__ import annotations
 
+import json
+
 import httpx2 as httpx
+
+
+# A Photon feature response for limit=1 is a few kB. Anything approaching this
+# is a geocoder that has been replaced or has gone wrong, and /resolve buffers
+# the body on every request — so cap it rather than trust the far end.
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 
 
 class PhotonClient:
@@ -44,13 +52,19 @@ class PhotonClient:
 
     def _query(self, q: str) -> tuple[float, float] | None:
         try:
-            resp = self._client.get(
+            with self._client.stream(
+                "GET",
                 f"{self._base}/api",
                 params={"q": q, "limit": 1},
                 timeout=self._timeout,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            ) as resp:
+                resp.raise_for_status()
+                body = bytearray()
+                for chunk in resp.iter_bytes():
+                    body += chunk
+                    if len(body) > _MAX_RESPONSE_BYTES:
+                        return None
+            data = json.loads(bytes(body))
             feats = data.get("features") or []
             if not feats:
                 return None

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -587,3 +587,23 @@ class TestDownloadCap:
             return httpx.Response(200, content=b"payload")
 
         assert data_loader._download_zip(self._client(handler), "https://x/f.zip") == b"payload"
+
+    def test_discover_zip_urls_caps_the_listing(self, monkeypatch):
+        """The directory listing is fetched first on a cold cache, before any
+        capped ZIP download — so it needs the ceiling too."""
+        monkeypatch.setattr(data_loader.settings, "max_download_mb", 1, raising=False)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"<a href=\"x.zip\">" + b"p" * (2 * 1024 * 1024))
+
+        assert data_loader._discover_zip_urls(self._client(handler), "https://x/") == []
+
+    def test_discover_zip_urls_still_parses_a_normal_listing(self, monkeypatch):
+        monkeypatch.setattr(data_loader.settings, "max_download_mb", 1, raising=False)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b'<a href="pc2024_DE.zip">DE</a>')
+
+        assert data_loader._discover_zip_urls(self._client(handler), "https://x/") == [
+            "https://x/pc2024_DE.zip"
+        ]

--- a/tests/test_photon_client.py
+++ b/tests/test_photon_client.py
@@ -109,3 +109,30 @@ def test_transport_error_returns_none():
 def test_blank_query_returns_none():
     pc = PhotonClient("http://photon", _client(lambda r: httpx.Response(200, json={"features": []})))
     assert pc.geocode(None, None, None) is None
+
+
+def test_oversized_geocoder_response_is_abandoned():
+    """/resolve buffers the geocoder body on every request — a Photon that has
+    been replaced or has gone wrong must not be able to exhaust the worker."""
+    from app import photon_client
+
+    def handler(req):
+        return httpx.Response(200, content=b"x" * (photon_client._MAX_RESPONSE_BYTES + 1))
+
+    pc = PhotonClient("http://photon", _client(handler))
+    assert pc.geocode("Markt", "Tervuren", "3080") is None
+
+
+def test_response_just_under_the_cap_still_parses():
+    """The cap must not clip a legitimate response."""
+    from app import photon_client
+
+    feature = {"geometry": {"type": "Point", "coordinates": [4.5149, 50.8246]}}
+    padding = "y" * 1024  # well under the ceiling, but not trivially small
+
+    def handler(req):
+        return httpx.Response(200, json={"features": [feature], "note": padding})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    assert pc.geocode("Markt", "Tervuren", "3080") == (50.8246, 4.5149)
+    assert photon_client._MAX_RESPONSE_BYTES > len(padding)


### PR DESCRIPTION
Follow-up to #167, from the Codex review on that PR.

**`_discover_zip_urls`** buffered the TERCET directory listing with `client.get` + `resp.text`. It runs *first* on a cold cache, before any of the ZIP downloads #167 capped — so an oversized listing exhausted the worker while `PC2NUTS_MAX_DOWNLOAD_MB` never came into play. The README's startup-download protection did not cover the first request of a cold start. Now routed through `_get_capped`, with `DownloadTooLarge` handled alongside the existing transport errors (the function already degrades to "no URLs discovered").

**`PhotonClient._query`** buffered the geocoder response on every `/resolve` request — the only remote body on the hot path. Photon is loopback in production so the trust level is higher, but a `limit=1` feature response is a few kB and the 2 MB ceiling is far above anything legitimate. On breach it returns `None`, which the cascade already treats as "no geocode" and falls back to the postal result, so the "never raises" contract holds.

Four tests: both caps trip on an oversized body, and both still parse a normal one (the second half matters — a cap that clips legitimate responses is worse than none).

`pytest` 474 passed, ruff clean, bandit exit 0.