### PR TITLE
fix(security): ask Photon for uncompressed responses

### DIFF
--- a/app/photon_client.py
+++ b/app/photon_client.py
@@ -26,6 +26,11 @@ import httpx2 as httpx
 # the body on every request — so cap it rather than trust the far end.
 _MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 
+# Photon is loopback, so compression buys nothing — ask for none. Without this,
+# the byte ceiling above counts *decoded* bytes, and a compressed body only
+# reveals its true size after inflation.
+_NO_COMPRESSION = {"Accept-Encoding": "identity"}
+
 
 class PhotonClient:
     def __init__(self, base_url: str, client: httpx.Client, timeout: float = 5.0):
@@ -56,6 +61,7 @@ class PhotonClient:
                 "GET",
                 f"{self._base}/api",
                 params={"q": q, "limit": 1},
+                headers=_NO_COMPRESSION,
                 timeout=self._timeout,
             ) as resp:
                 resp.raise_for_status()

--- a/tests/test_photon_client.py
+++ b/tests/test_photon_client.py
@@ -136,3 +136,42 @@ def test_response_just_under_the_cap_still_parses():
     pc = PhotonClient("http://photon", _client(handler))
     assert pc.geocode("Markt", "Tervuren", "3080") == (50.8246, 4.5149)
     assert photon_client._MAX_RESPONSE_BYTES > len(padding)
+
+
+def test_requests_uncompressed_responses():
+    """The byte ceiling counts decoded bytes, so a compressed body only reveals
+    its true size after inflation. Photon is loopback — ask for no compression."""
+    seen = []
+
+    def handler(req):
+        seen.append(req.headers.get("accept-encoding"))
+        return httpx.Response(200, json={"features": []})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    pc.geocode("Markt", "Tervuren", "3080")
+    assert seen and all(enc == "identity" for enc in seen)
+
+
+def test_compressed_oversized_response_is_abandoned():
+    """Belt and braces: even if the far end ignores Accept-Encoding and gzips a
+    huge body, the cap holds and nothing near the decompressed size is retained."""
+    import gzip
+
+    from app import photon_client
+
+    bomb = gzip.compress(b"\0" * (64 * 1024 * 1024))
+
+    class _Stream(httpx.SyncByteStream):
+        def __iter__(self):
+            for i in range(0, len(bomb), 65536):
+                yield bomb[i : i + 65536]
+
+        def close(self):
+            pass
+
+    def handler(req):
+        return httpx.Response(200, stream=_Stream(), headers={"Content-Encoding": "gzip"})
+
+    pc = PhotonClient("http://photon", _client(handler))
+    assert pc.geocode("Markt", "Tervuren", "3080") is None
+    assert len(bomb) < photon_client._MAX_RESPONSE_BYTES  # the wire body alone would have passed


### PR DESCRIPTION
Follow-up to #168.

The 2 MB ceiling on the geocoder body counts **decoded** bytes, so a compressed response only reveals its true size after inflation. Photon runs on loopback, where compression buys nothing — so send `Accept-Encoding: identity` and take the question off the table.

To be clear about what this is not: the cap was never bypassable. `httpx2` 2.12 bounds decoder output at `MAX_DECODE_CHUNK_SIZE` (1 MiB, 512 KiB for brotli) and `Response.iter_bytes()` pipes those pieces straight through, so a decompression bomb cannot materialise as one giant chunk — worst case is 2 MiB buffered plus 1 MiB in flight, measured. See https://github.com/bk86a/PostalCode2NUTS/pull/168#discussion_r3883775796. This change just stops the ceiling depending on a library internal.

Tests: one asserting every Photon request sends `Accept-Encoding: identity`, and one belt-and-braces case gzipping a 64 MiB body over a streaming transport (wire size well under the cap) to confirm the cap still holds if the far end ignores the header.