### PR TITLE
feat(pattern): narrow the regex to a territory's own postal range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- `GET /pattern` now returns a regex narrowed to the territory's own postal range
+  for the six ISO-coded territories that are both linked to NUTS and postal-coded:
+  `GP`, `MQ`, `GF`, `RE`, `YT` and `SJ`. Previously it echoed the administering
+  country's pattern verbatim, so `/pattern?country=RE` validated Paris's `75001`
+  as a Réunion code while `/lookup?country=RE&postal_code=75001` correctly refused
+  it. Only the digits are restricted - the parent's accepted country prefixes
+  (`F-`, `FR-`, `NO-`) still validate - and the `example` field is rebuilt around a
+  code from the territory's own range.
+- No `/lookup` behaviour change: it already gated on the registry's own ranges.
+  This closes a reporting gap, not a validation gap.
+- Territories that fail either condition are unchanged: the OCTs and Saint-Martin
+  have postal codes but no NUTS link, and the Crown Dependencies have no prefix
+  range to narrow to.
+
 ### Security
 
 - **Rate limiting could be bypassed by any caller.** The image ran uvicorn with

--- a/README.md
+++ b/README.md
@@ -402,10 +402,28 @@ GET /pattern?country=AT
 }
 ```
 
-A territory code returns the administering country's pattern — `GET /pattern?country=RE`
-echoes `country_code: "RE"` with FR's regex. Aruba, Curaçao, Sint Maarten and Bonaire/Saba/Sint
-Eustatius (`AW`, `CW`, `SX`, `BQ`) use no postal codes at all, so this endpoint returns `404`
-for them rather than a pattern.
+**Territory codes.** A territory that meets both conditions — it is linked to NUTS, and it has
+postal codes of its own — gets a pattern narrowed to its own range rather than the administering
+country's whole numbering space. Six ISO-coded territories qualify:
+
+| `country` | Regex | Example | Narrowed from |
+|---|---|---|---|
+| `GP` | `^(?:F[…]*\|FR[…]*)?(971[0-9]{2})$` | `97100, F-97100, FR-97100` | FR |
+| `MQ` | `^(?:F[…]*\|FR[…]*)?(972[0-9]{2})$` | `97200, F-97200, FR-97200` | FR |
+| `GF` | `^(?:F[…]*\|FR[…]*)?(973[0-9]{2})$` | `97300, F-97300, FR-97300` | FR |
+| `RE` | `^(?:F[…]*\|FR[…]*)?(974[0-9]{2})$` | `97400, F-97400, FR-97400` | FR |
+| `YT` | `^(?:F[…]*\|FR[…]*)?(976[0-9]{2})$` | `97600, F-97600, FR-97600` | FR |
+| `SJ` | `^(?:N[…]*\|NO[…]*)?(8099\|917[0-9])$` | `8099, N-8099, NO-8099` | NO |
+
+Only the digits are restricted; the parent country's accepted prefixes (`F-`, `FR-`, `NO-`) still
+validate. So `/pattern?country=RE` no longer accepts Paris's `75001` as a Réunion code, which
+matches what `/lookup?country=RE&postal_code=75001` has always answered.
+
+Every other territory code still returns the administering country's pattern unchanged: the OCTs
+and Saint-Martin have postal codes but no NUTS link, and the Crown Dependencies have no prefix
+range to narrow to. Aruba, Curaçao, Sint Maarten and Bonaire/Saba/Sint Eustatius (`AW`, `CW`,
+`SX`, `BQ`) use no postal codes at all, so this endpoint returns `404` for them rather than a
+pattern.
 
 ### `GET /resolve`
 

--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ from app.models import (
 )
 from app.nuts_polygons import load_nuts_pip
 from app.photon_client import PhotonClient
-from app.postal_patterns import PATTERNS_META, POSTAL_PATTERNS
+from app.postal_patterns import PATTERNS_META, POSTAL_PATTERNS, narrow_to_ranges
 from app.resolver import resolve as _resolve
 from app.territories import (
     count as territory_count,
@@ -420,6 +420,12 @@ def get_pattern(
                 detail=f"{terr.name} uses no postal codes.",
             )
         pattern = POSTAL_PATTERNS.get(terr.validate_as)
+        # A territory Eurostat classifies resolves to a NUTS code of its own, so
+        # the pattern it advertises must describe its own range rather than the
+        # administering country's whole numbering space: FR's pattern would call
+        # Paris's 75001 a valid Réunion code, which /lookup already refuses.
+        if pattern is not None and terr.in_nuts:
+            pattern = narrow_to_ranges(pattern, terr.exact, terr.prefixes) or pattern
     else:
         pattern = POSTAL_PATTERNS.get(cc)
     if pattern is None:

--- a/app/postal_patterns.py
+++ b/app/postal_patterns.py
@@ -130,3 +130,50 @@ def extract_postal_code(country_code: str, raw_input: str) -> str:
                 code = _apply_tercet_map(code, tercet_map)
             return code
     return normalize_postal_code(cleaned)
+
+
+# The single all-digit capture group that every narrowable parent pattern uses,
+# e.g. FR's ``([0-9]{5})``. Territories carve a prefix range out of that group.
+_DIGIT_GROUP = re.compile(r"\(\[0-9\]\{(\d+)\}\)")
+
+
+def narrow_to_ranges(parent: dict, exact: tuple[str, ...], prefixes: tuple[str, ...]) -> dict | None:
+    """Restrict a parent country's pattern to a territory's own postal ranges.
+
+    A territory validated against its administering country accepts that country's
+    whole numbering space, so FR's pattern would call Paris's ``75001`` a valid
+    Réunion code. ``/lookup`` already rejects it — the registry knows Réunion is
+    ``974xx`` — so this narrows the *reported* pattern to the same ranges, leaving
+    the parent's accepted country prefixes (``F-``, ``FR-``) untouched.
+
+    Returns None when narrowing is not possible: no ranges to narrow to, or a
+    parent pattern that is not a single all-digit group (only FR and NO are needed
+    today; PT and ES split their codes across two groups). Callers fall back to
+    the parent pattern unchanged.
+    """
+    if not exact and not prefixes:
+        return None
+    digits = parent.get("expected_digits")
+    if not digits:
+        return None
+    groups = _DIGIT_GROUP.findall(parent["regex"])
+    if len(groups) != 1 or int(groups[0]) != digits:
+        return None
+
+    alternatives = list(exact)
+    for prefix in prefixes:
+        rest = digits - len(prefix)
+        if rest < 0:
+            return None
+        alternatives.append(prefix + {0: "", 1: "[0-9]"}.get(rest, f"[0-9]{{{rest}}}"))
+
+    regex = _DIGIT_GROUP.sub("(" + "|".join(alternatives) + ")", parent["regex"], count=1)
+
+    # Rebuild the example around a real code from the territory's own range, so
+    # "75001, F-75001, FR-75001" becomes "97400, F-97400, FR-97400".
+    sample = exact[0] if exact else prefixes[0].ljust(digits, "0")
+    example = parent.get("example", "")
+    parent_sample = re.search(r"\d{2,}", example)
+    example = example.replace(parent_sample.group(), sample) if parent_sample else sample
+
+    return {**parent, "regex": regex, "example": example}

--- a/tests/test_territory_api.py
+++ b/tests/test_territory_api.py
@@ -1,5 +1,7 @@
 """Endpoint behaviour for outermost regions, OCTs and other non-NUTS territories."""
 
+import re
+
 from app import data_loader
 
 
@@ -66,9 +68,19 @@ def test_unsupported_country_still_400s(client):
     assert r.status_code == 400
 
 
-def test_pattern_returns_the_parent_pattern_for_a_territory(client):
+def test_pattern_narrows_to_the_territorys_own_range_when_it_is_in_nuts(client):
+    """A territory Eurostat classifies advertises its own range, not the parent's:
+    FR's pattern would validate Paris's 75001 as a Réunion code."""
     body = client.get("/pattern", params={"country": "RE"}).json()
     assert body["country_code"] == "RE"
+    assert body["regex"] != client.get("/pattern", params={"country": "FR"}).json()["regex"]
+    assert re.match(body["regex"], "97400")
+    assert not re.match(body["regex"], "75001")
+
+
+def test_pattern_keeps_the_parent_pattern_for_a_territory_outside_nuts(client):
+    """Deliberate scope: only the NUTS-linked territories are narrowed for now."""
+    body = client.get("/pattern", params={"country": "NC"}).json()
     assert body["regex"] == client.get("/pattern", params={"country": "FR"}).json()["regex"]
 
 

--- a/tests/test_territory_patterns.py
+++ b/tests/test_territory_patterns.py
@@ -1,0 +1,111 @@
+"""Narrowed /pattern regexes for territories that are both in NUTS and postal-coded.
+
+Two conditions, and only both together:
+  1. the territory is linked to NUTS (`in_nuts`), so it resolves to a code of its own;
+  2. it has postal codes at all (`has_postal_system`).
+
+Only then does /pattern advertise the territory's own range instead of the
+administering country's whole numbering space.
+"""
+
+import re
+
+import pytest
+
+from app import territories
+from app.postal_patterns import POSTAL_PATTERNS, narrow_to_ranges
+
+# (iso, parent, an in-range code, an out-of-range parent code)
+QUALIFYING = [
+    ("GP", "FR", "97110", "75001"),
+    ("MQ", "FR", "97200", "75001"),
+    ("GF", "FR", "97300", "75001"),
+    ("RE", "FR", "97400", "75001"),
+    ("YT", "FR", "97600", "75001"),
+    ("SJ", "NO", "9170", "0150"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit():
+    """The limiter's 120/minute budget is per-IP and every TestClient shares the
+    'testclient' host, so a module this endpoint-heavy would otherwise spend the
+    whole suite's allowance and 429 whichever test happens to run last."""
+    from app.limiter import limiter
+
+    limiter.reset()
+    yield
+
+
+def _iso_territories():
+    return [t for t in territories._registry if t.iso]
+
+
+def test_exactly_six_iso_coded_territories_meet_both_conditions():
+    qualifying = {t.iso for t in _iso_territories() if t.in_nuts and t.has_postal_system}
+    assert qualifying == {iso for iso, *_ in QUALIFYING}
+
+
+@pytest.mark.parametrize("iso,parent,in_range,out_of_range", QUALIFYING)
+def test_qualifying_territory_gets_its_own_range(client, iso, parent, in_range, out_of_range):
+    r = client.get("/pattern", params={"country": iso})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["country_code"] == iso
+    assert re.match(body["regex"], in_range), f"{iso} must accept its own code {in_range}"
+    assert not re.match(body["regex"], out_of_range), (
+        f"{iso} must reject {out_of_range}, which is {parent}'s but not {iso}'s"
+    )
+    # The example must be a code the pattern itself accepts.
+    assert re.match(body["regex"], body["example"].split(",")[0].strip())
+
+
+@pytest.mark.parametrize("iso,parent,in_range,_out", QUALIFYING)
+def test_qualifying_territory_still_accepts_the_parents_country_prefixes(client, iso, parent, in_range, _out):
+    """Narrowing restricts the digits, not the accepted `F-` / `NO-` prefixes."""
+    rx = client.get("/pattern", params={"country": iso}).json()["regex"]
+    for prefixed in (in_range, f"{parent[0]}-{in_range}", f"{parent}-{in_range}"):
+        assert re.match(rx, prefixed), f"{iso} must still accept {prefixed}"
+
+
+def test_territory_failing_either_condition_keeps_the_parent_pattern(client):
+    """Fails condition 1 (not in NUTS) -> unchanged, even though it has postal codes."""
+    for iso, parent in (("NC", "FR"), ("GL", "DK"), ("MF", "FR"), ("BL", "FR")):
+        t = territories.get_by_iso(iso)
+        assert t.has_postal_system and not t.in_nuts
+        body = client.get("/pattern", params={"country": iso}).json()
+        assert body["regex"] == client.get("/pattern", params={"country": parent}).json()["regex"]
+
+
+def test_territory_with_no_postal_system_has_no_range_to_narrow_to():
+    """Fails condition 2 -> nothing to narrow. (The endpoint's own answer for these
+    is covered in test_territory_api.py; this pins the rule, not the error shape.)"""
+    for iso in ("AW", "CW", "SX", "BQ"):
+        t = territories.get_by_iso(iso)
+        assert not t.has_postal_system
+        assert not t.exact and not t.prefixes
+        assert narrow_to_ranges(POSTAL_PATTERNS["FR"], t.exact, t.prefixes) is None
+
+
+def test_ordinary_country_patterns_are_untouched(client):
+    for cc in ("FR", "NO", "DK", "DE", "PL"):
+        assert (
+            client.get("/pattern", params={"country": cc}).json()["regex"] == (POSTAL_PATTERNS[cc]["regex"])
+        )
+
+
+class TestNarrowToRanges:
+    def test_exact_codes_and_prefixes_combine(self):
+        out = narrow_to_ranges(POSTAL_PATTERNS["NO"], ("8099",), ("917",))
+        assert "(8099|917[0-9])" in out["regex"]
+
+    def test_returns_none_without_ranges(self):
+        assert narrow_to_ranges(POSTAL_PATTERNS["FR"], (), ()) is None
+
+    def test_returns_none_for_a_two_group_parent_pattern(self):
+        # PT splits its code across two groups; narrowing is not attempted.
+        assert narrow_to_ranges(POSTAL_PATTERNS["PT"], (), ("95",)) is None
+
+    def test_narrowed_pattern_keeps_the_parents_other_keys(self):
+        out = narrow_to_ranges(POSTAL_PATTERNS["FR"], (), ("974",))
+        assert out["expected_digits"] == POSTAL_PATTERNS["FR"]["expected_digits"]


### PR DESCRIPTION
## The bug

`/pattern` — the postal-code **validation** endpoint (`/lookup` resolves, `/pattern` returns the regex used to validate and extract) — echoed the administering country's regex verbatim for every territory:

```
GET /pattern?country=RE
{"country_code": "RE",
 "regex": "^(?:F[\\s\\-–—.]*|FR[\\s\\-–—.]*)?([0-9]{5})$",
 "example": "75001, F-75001, FR-75001"}
```

That regex accepts **`75001` — Paris** as a valid Réunion code, and the example offered for Réunion is a Paris code. `/pattern?country=SJ` likewise accepted `0150` (Oslo) for Svalbard.

`/lookup` has always refused those inputs — the registry knows Réunion is `974xx` and Svalbard `917xx`/`8099` — so the data was there; `/pattern` just ignored it. **This is a reporting gap, not a validation gap**, which is why there is no `/lookup` change here.

## The rule

Narrowing applies where **both** conditions hold:

1. the territory is linked to NUTS (`in_nuts`), so it resolves to a code of its own; **and**
2. it has postal codes at all (`has_postal_system`).

Six ISO-coded territories qualify. Verified against the registry, not assumed:

| `country` | Regex after | Example after | From |
|---|---|---|---|
| `GP` | `…?(971[0-9]{2})$` | `97100, F-97100, FR-97100` | FR |
| `MQ` | `…?(972[0-9]{2})$` | `97200, F-97200, FR-97200` | FR |
| `GF` | `…?(973[0-9]{2})$` | `97300, F-97300, FR-97300` | FR |
| `RE` | `…?(974[0-9]{2})$` | `97400, F-97400, FR-97400` | FR |
| `YT` | `…?(976[0-9]{2})$` | `97600, F-97600, FR-97600` | FR |
| `SJ` | `…?(8099\|917[0-9])$` | `8099, N-8099, NO-8099` | NO |

Only the **digits** are restricted — the parent's accepted country prefixes (`F-`, `FR-`, `NO-`) still validate, so the advertised pattern matches exactly what `/lookup` accepts for that ISO code.

**Who does not qualify, and why:**
- `MF`, `GL`, `PF`, `NC`, `WF`, `PM`, `BL`, `TF` — postal codes, but no NUTS link (condition 1)
- `ES-CN`, `PT-20`, `PT-30` — NUTS link, but no ISO alpha-2 code, so unreachable via `/pattern`
- `FO`, `GI`, `JE`, `GG`, `IM` — no NUTS link, and whole-country with no prefix range to narrow to
- `AW`, `CW`, `SX`, `BQ` — no postal codes at all (condition 2)

## Known follow-up

The OCTs fail condition 1 but have the *same* bug: `/pattern?country=NC` still returns FR's regex and still accepts `75001`. Scoping this PR to the NUTS-linked six was a deliberate call; extending it to the eight narrowable OCTs is a one-line condition change and no new machinery. `test_pattern_keeps_the_parent_pattern_for_a_territory_outside_nuts` pins the current behaviour so the follow-up is a visible, intentional edit rather than a silent drift.

## Implementation

`narrow_to_ranges()` in `app/postal_patterns.py` substitutes the parent's single all-digit capture group with an alternation built from the registry's `exact` codes and `prefixes`. It returns `None` — caller falls back to the parent pattern untouched — when there are no ranges, no `expected_digits`, or the parent splits its code across two groups (PT, ES), so it cannot silently emit a wrong pattern.

## Tests

`495 passed`. New `tests/test_territory_patterns.py` (20 tests):

- `test_exactly_six_iso_coded_territories_meet_both_conditions` derives the qualifying set from the registry and asserts it equals the six, so adding a territory to `territories.json` cannot silently change the scope
- each of the six accepts an in-range code, **rejects** the parent's out-of-range code, still accepts the parent's country prefixes, and returns an `example` its own regex matches
- territories failing either condition are asserted unchanged
- ordinary countries (`FR`, `NO`, `DK`, `DE`, `PL`) are asserted byte-identical to `postal_patterns.json`
- unit tests for `narrow_to_ranges` including the two-capture-group bail-out

`test_pattern_returns_the_parent_pattern_for_a_territory` pinned the old behaviour and was rewritten rather than deleted.

One incidental fix: the module resets the rate limiter per test. The limiter's 120/min budget is per-IP and every `TestClient` shares the `testclient` host, so this endpoint-heavy module otherwise spent the suite's allowance and 429'd whichever test ran last.