### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [3.0.0] - 2026-08-28
+## [3.0.0] - 2026-08-29
 
 Absence of data is no longer an HTTP error. A well-formed query against a served
 route always answers `200`, carrying a `found` flag and a human-readable

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,0 +1,117 @@
+# PostalCode2NUTS 3.0.0 — Missing data is not an error
+
+Two breaking changes, both about telling the truth in the response body rather than in the
+status line: a well-formed query always answers `200`, and the block describing where a code
+sits is no longer named after only one of the three kinds of place it describes.
+
+## Why
+
+`404` was doing two incompatible jobs. `GET /lookup?country=DE&postal_code=99999` and
+`GET /nope` both returned it — one means "that postal code has no NUTS mapping", the other
+means "that URL is not part of this API". A client could not tell a data gap from a broken
+integration without inspecting the body it had just been told was an error, and every caching
+layer between the two treated a perfectly good answer as a failure.
+
+The `territory` block had a narrower problem. It is returned for Réunion, for New Caledonia and
+for Jersey. Réunion is a French region and a NUTS-2 unit — not a territory of France in any
+sense the word carries. Curaçao is a constituent country of the Kingdom of the Netherlands.
+Naming the block for one of the three categories described the other two wrongly.
+
+## What's new
+
+**`found` and `message` on every answer.** A miss is now a `200` that says so:
+
+```json
+GET /lookup?country=DE&postal_code=99999   → 200
+{
+  "found": false,
+  "message": "No NUTS mapping found for postal code '99999' in country 'DE'. Expected format: 10115, D-10115, DE-10115, D 10115",
+  "postal_code": "99999", "country_code": "DE", "code_system": "NUTS",
+  "match_type": null, "nuts1": null, "nuts2": null, "nuts3": null, "context": null
+}
+```
+
+`404` now means one thing only: the URL is not a route of this API. `401`, `422` and `429` are
+untouched — they describe the request, not the data.
+
+**A miss is cacheable.** `Cache-Control` now covers the not-found answer, so repeated queries
+for a code that does not exist are served from the edge like any hit.
+
+**`found: true` with a `message`** marks a partial hit — the code is recognised, but the place
+sits outside NUTS, so the `nuts*` fields are null by construction (`FO/100`, `NC/98800`). Those
+were already `200` in 2.x; nothing changes for them.
+
+**The `context` block.** Same fields, neutral name:
+
+```diff
+-  "territory": {
++  "context": {
+     "id": "NC", "name": "New Caledonia", "status": "oct",
+     "administering_country": "FR", "legal_basis": "TFEU Part Four, Annex II",
+     "nuts_coverage": "none"
+   }
+```
+
+Nothing inside the block moves — `id`, `iso`, `name`, `status`, `administering_country`,
+`legal_basis`, `note` and `nuts_coverage` are all unchanged. `TerritoryInfo` becomes
+`ContextInfo` in the OpenAPI schema.
+
+## What's breaking
+
+| Case | 2.x | 3.0.0 |
+|---|---|---|
+| `/lookup` postal code with no mapping | `404` | `200` `found:false` |
+| `/lookup` code outside the named territory (`GL/2100`) | `404` | `200` `found:false` |
+| `/lookup` malformed territory code (`NC/12345`) | `404` | `200` `found:false` |
+| `/lookup` country not served (`ZZ`) | `400` | `200` `found:false` |
+| `/pattern` country with no pattern | `404` | `200` `found:false`, `regex:null` |
+| `/pattern` territory with no postal system (`AW`) | `404` | `200` `found:false`, `regex:null` |
+| `/resolve` country not served | `400` | `200` `found:false`, `resolved_via:"none"` |
+| `territory` key on `/lookup` and `/resolve` | present | renamed to `context` |
+| Unknown route (`/lookup/DE`, `/nope`) | `404` | `404` — unchanged, the genuine case |
+
+The rename is a rename, not an alias: `territory` is **absent** from the body, so a client
+reading it gets a `KeyError` rather than a silent `None`. That is deliberate — a null would
+look like "ordinary lookup, no territory" for every OCT response.
+
+## Also in this release
+
+**`/pattern` no longer advertises the wrong range for a territory.** It echoed the administering
+country's regex verbatim, so `/pattern?country=RE` accepted Paris's `75001` as a Réunion code and
+offered it as the example. Six ISO-coded territories that are both NUTS-linked and postal-coded
+now get their own range — `GP` `971xx`, `MQ` `972xx`, `GF` `973xx`, `RE` `974xx`, `YT` `976xx`,
+`SJ` `8099`/`917x` — with the parent's country prefixes (`F-`, `FR-`, `NO-`) still valid.
+`/lookup` always refused those codes; this closes a reporting gap, not a validation gap.
+
+**Security.** Rate limiting could be bypassed by rotating `X-Forwarded-For` — the image now
+trusts only `PC2NUTS_FORWARDED_ALLOW_IPS` (default `127.0.0.1`), **which operators must set to
+their reverse proxy's address or CIDR**. Trusted tokens under 32 characters are refused at
+startup; settings-validation failures no longer print the token values into container logs;
+every remote body the worker buffers is capped, the TERCET listing and the Photon geocoder
+response included; Photon is asked for uncompressed responses so the cap counts wire bytes.
+
+**Docs.** `docs/overseas_territories.md` now names all thirteen Annex II OCTs rather than eleven
+ISO codes — Bonaire, Saba and Sint Eustatius share `BQ` and were never individually named. A
+test parses the table and checks it against the registry, so it cannot drift.
+
+## What stays the same
+
+Every resolution result. No lookup that returned a NUTS code in 2.0.0 returns anything different
+here — the coverage, confidence and match-type semantics are untouched, and the internal registry
+keeps its names (`app/territories.py`, `app/territories.json`, `classify()`). This release changes
+how the service reports, not what it knows.
+
+## Upgrading
+
+```diff
+-if r.status_code == 404: handle_missing()
+-elif r.status_code == 400: handle_unsupported_country()
++r.raise_for_status()          # 422 / 429 / 401 still raise
++body = r.json()
++if not body["found"]: handle_missing(body["message"])
+
+-territory = body.get("territory")
++context = body.get("context")
+```
+
+See [Upgrading to 3.0.0](../../README.md#upgrading-to-300) in the README.


### PR DESCRIPTION
Release notes for 3.0.0 plus the CHANGELOG date.

- `docs/releases/v3.0.0.md` in the style of `v2.0.0.md`: why `404` was doing two jobs, the `found`/`message` contract, the `territory` → `context` rename, a before/after table of every changed case, the `/pattern` narrowing, the security fixes since 2.0.0, the thirteen-OCT docs fix, and a migration diff.
- `CHANGELOG.md`: `## [3.0.0]` dated 2026-08-29, the day it is tagged.

Every JSON body and message string quoted in the notes was read back out of the running app or `app/main.py`, not transcribed from a PR description. No code change.