### PR TITLE
docs: scope two over-broad claims in the 3.0.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ longer emits `400`. `404` now means only that the URL is not a route of this API
 
 Three response models gain `found` (bool) and `message` (string or null); `PatternResponse.regex`
 and `PatternResponse.example` become nullable. Clients with strict schemas must widen those
-types.
+types. `GET /pattern` with no `country` is unaffected — it is a listing, so it still returns a
+plain array of country codes with no `found` field to branch on.
 
 **The `territory` block is renamed to `context`** (`TerritoryInfo` → `ContextInfo`). It covers
 three kinds of place — outermost regions, which are integral parts of a Member State; overseas

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -85,4 +85,4 @@ Eurostat codes that merely lack a TERCET file, and neither is fabricated.
 
 ## Upgrading
 
-See [Upgrading to 2.0.0](../../README.md#upgrading-to-200) in the README.
+See [Upgrading to 2.0.0](https://github.com/bk86a/PostalCode2NUTS/blob/main/README.md#upgrading-to-200) in the README.

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -19,7 +19,7 @@ Naming the block for one of the three categories described the other two wrongly
 
 ## What's new
 
-**`found` and `message` on every answer.** A miss is now a `200` that says so:
+**`found` and `message` on every answer that carries data.** A miss is now a `200` that says so:
 
 ```json
 GET /lookup?country=DE&postal_code=99999   → 200
@@ -33,6 +33,11 @@ GET /lookup?country=DE&postal_code=99999   → 200
 
 `404` now means one thing only: the URL is not a route of this API. `401`, `422` and `429` are
 untouched — they describe the request, not the data.
+
+One shape is deliberately unchanged: `GET /pattern` with no `country` is a listing, not a
+lookup, and still returns a bare JSON array of the codes it serves. It has no `found` field
+because it cannot miss — branch on `found` only for the three response models
+(`NUTSResult`, `PatternResponse`, `ResolveResponse`).
 
 **A miss is cacheable.** `Cache-Control` now covers the not-found answer, so repeated queries
 for a code that does not exist are served from the edge like any hit.
@@ -85,8 +90,9 @@ now get their own range — `GP` `971xx`, `MQ` `972xx`, `GF` `973xx`, `RE` `974x
 
 **Security.** Rate limiting could be bypassed by rotating `X-Forwarded-For` — the image now
 trusts only `PC2NUTS_FORWARDED_ALLOW_IPS` (default `127.0.0.1`), **which operators must set to
-their reverse proxy's address or CIDR**. Trusted tokens under 32 characters are refused at
-startup; settings-validation failures no longer print the token values into container logs;
+their reverse proxy's address or CIDR**. Tokens in `PC2NUTS_TRUSTED_TOKENS` shorter than 32
+characters are refused at startup — the DB-backed registry is unaffected, where the floor is
+enforced by `scripts.tokens add` rather than at load time; settings-validation failures no longer print the token values into container logs;
 every remote body the worker buffers is capped, the TERCET listing and the Photon geocoder
 response included; Photon is asked for uncompressed responses so the cap counts wire bytes.
 
@@ -107,7 +113,7 @@ how the service reports, not what it knows.
 -if r.status_code == 404: handle_missing()
 -elif r.status_code == 400: handle_unsupported_country()
 +r.raise_for_status()          # 422 / 429 / 401 still raise
-+body = r.json()
++body = r.json()                # a lookup/pattern/resolve answer, not the /pattern listing
 +if not body["found"]: handle_missing(body["message"])
 
 -territory = body.get("territory")

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -120,4 +120,4 @@ how the service reports, not what it knows.
 +context = body.get("context")
 ```
 
-See [Upgrading to 3.0.0](../../README.md#upgrading-to-300) in the README.
+See [Upgrading to 3.0.0](https://github.com/bk86a/PostalCode2NUTS/blob/main/README.md#upgrading-to-300) in the README.


### PR DESCRIPTION
Both raised by Codex on #171, both verified in code.

**`found`/`message` is not on *every* answer.** `GET /pattern` with no `country` returns a bare `list[str]` (the `if country is None` branch of `get_pattern`), so the blanket promise plus the migration snippet's unconditional `body["found"]` would hand a client a `TypeError` on the documented list-all call. The notes now say the contract covers `NUTSResult`, `PatternResponse` and `ResolveResponse`, and name the listing as the deliberate exception; the README's *Upgrading to 3.0.0* section says the same.

**The 32-character token floor is env-only.** `Settings._check_trusted_token_length` (`app/config.py:96`) validates `PC2NUTS_TRUSTED_TOKENS`; `refresh_db_tokens` (`app/auth.py:147`) builds its set from every nonempty `value` with no length test, so a row inserted directly into the registry stays active. `scripts.tokens add` enforces the floor at write time, not at load time. The CHANGELOG already said "Tokens from the DB registry are unaffected" - the release notes had dropped the qualifier, which is exactly the reading an operator should not take from a security note.

Docs only. The published GitHub Release body will be updated from this file once merged.